### PR TITLE
feat(cli): add interactive /resume and /model pickers with incremental session persistence

### DIFF
--- a/cli/source/app.js
+++ b/cli/source/app.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect, useMemo, useRef} from 'react';
 import {Box, Text, useInput, useApp} from 'ink';
 import TextInput from 'ink-text-input';
 import Spinner from 'ink-spinner';
@@ -135,19 +135,86 @@ const StatusMessage = ({message, isThinking}) => {
 	);
 };
 
+const parseTimestamp = value => {
+	const parsed = Date.parse(value || '');
+	return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const formatRelativeTime = value => {
+	if (!value) return '-';
+	const timestamp = parseTimestamp(value);
+	if (!timestamp) return '-';
+
+	const diffMs = Date.now() - timestamp;
+	const absMs = Math.abs(diffMs);
+	const units = [
+		{label: 'day', ms: 24 * 60 * 60 * 1000},
+		{label: 'hour', ms: 60 * 60 * 1000},
+		{label: 'minute', ms: 60 * 1000},
+		{label: 'second', ms: 1000},
+	];
+
+	for (const unit of units) {
+		if (absMs >= unit.ms || unit.label === 'second') {
+			const amount = Math.max(1, Math.floor(absMs / unit.ms));
+			const suffix = amount === 1 ? '' : 's';
+			return diffMs >= 0
+				? `${amount} ${unit.label}${suffix} ago`
+				: `in ${amount} ${unit.label}${suffix}`;
+		}
+	}
+
+	return '-';
+};
+
+const truncateText = (value, maxLength) => {
+	if (!value) return '';
+	if (value.length <= maxLength) return value;
+	return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+};
+
+const toSingleLine = value =>
+	String(value || '')
+		.replace(/\s+/g, ' ')
+		.trim();
+
 export default function App({yamlPath}) {
 	const [messages, setMessages] = useState([]);
 	const [currentSteps, setCurrentSteps] = useState([]);
 	const [input, setInput] = useState('');
 	const [isProcessing, setIsProcessing] = useState(false);
+	const [isInterrupting, setIsInterrupting] = useState(false);
 	const [statusMessage, setStatusMessage] = useState('Initializing...');
 	const [isReady, setIsReady] = useState(false);
 	const [error, setError] = useState(null);
+	const [sessionInfo, setSessionInfo] = useState(null);
 	const [subAgentTraces, setSubAgentTraces] = useState(() => new Map());
 	const [activeSubAgentId, setActiveSubAgentId] = useState(null);
+	const [resumePickerOpen, setResumePickerOpen] = useState(false);
+	const [resumePickerLoading, setResumePickerLoading] = useState(false);
+	const [resumePickerError, setResumePickerError] = useState('');
+	const [resumeSessions, setResumeSessions] = useState([]);
+	const [resumeSearch, setResumeSearch] = useState('');
+	const [resumeSortBy, setResumeSortBy] = useState('updated_at');
+	const [resumeSelectedIndex, setResumeSelectedIndex] = useState(0);
+	const [modelPickerOpen, setModelPickerOpen] = useState(false);
+	const [modelPickerLoading, setModelPickerLoading] = useState(false);
+	const [modelPickerError, setModelPickerError] = useState('');
+	const [modelOptions, setModelOptions] = useState([]);
+	const [modelSearch, setModelSearch] = useState('');
+	const [modelSelectedIndex, setModelSelectedIndex] = useState(0);
 	const agentProcess = useRef(null);
+	const shutdownRequested = useRef(false);
 	const currentStepsRef = useRef([]);
 	const {exit} = useApp();
+	const resetConversationView = () => {
+		setMessages([]);
+		currentStepsRef.current = [];
+		setCurrentSteps([]);
+		setSubAgentTraces(new Map());
+		setActiveSubAgentId(null);
+		setError(null);
+	};
 
 	const ensureSubAgentEntry = (metadata = {}, content = '') => ({
 		agentId: metadata.agent_id || 'unknown',
@@ -177,46 +244,114 @@ export default function App({yamlPath}) {
 
 	useEffect(() => {
 		// Display welcome message
-		setMessages([{
-			role: 'assistant',
-			content: 'Welcome to NexAU Agent CLI! I\'m ready to help you with your tasks.\n\nAvailable commands:\n• Type your message to start a task\n• /clear - Clear the conversation history\n\nPress Esc or Ctrl+C to exit.',
-			steps: []
-		}]);
+		setMessages([
+			{
+				role: 'assistant',
+				content:
+					"Welcome to NexAU Agent CLI! I'm ready to help you with your tasks.\n\nAvailable commands:\n• Type your message to start a task\n• /clear - Start a fresh session\n• /interrupt - Stop the current run and keep the session\n• /resume - Open session picker\n• /model - Open model picker\n\nPress Esc to exit. Press Ctrl+C while running to interrupt.",
+				steps: [],
+			},
+		]);
 
 		// Start the Python agent process from the packaged module
 		const repoRoot = path.join(__dirname, '..', '..');
 		const pythonModule = 'nexau.cli.agent_runner';
-		const python = spawn('uv', ['run', 'python', '-m', pythonModule, yamlPath], {
-			cwd: repoRoot,
-		});
+		const python = spawn(
+			'uv',
+			['run', 'python', '-m', pythonModule, yamlPath],
+			{
+				cwd: repoRoot,
+			},
+		);
 
 		agentProcess.current = python;
 
 		python.stdout.on('data', data => {
-			const lines = data.toString().split('\n').filter(line => line.trim());
+			const lines = data
+				.toString()
+				.split('\n')
+				.filter(line => line.trim());
 
 			for (const line of lines) {
 				try {
 					const message = JSON.parse(line);
 					const metadata = message.metadata || {};
+					if (metadata.session_id || metadata.user_id || metadata.agent_id) {
+						setSessionInfo({
+							sessionId: metadata.session_id || '',
+							userId: metadata.user_id || '',
+							agentId: metadata.agent_id || '',
+							model: metadata.model || '',
+							storagePath: metadata.storage_path || '',
+							storageRawPath: metadata.storage_raw_path || '',
+							indexPath: metadata.index_path || '',
+							indexRawPath: metadata.index_raw_path || '',
+							restored: Boolean(metadata.restored),
+						});
+					}
 
 					switch (message.type) {
 						case 'status':
 							setStatusMessage(message.content);
 							break;
+						case 'session':
+							if (metadata.reset_ui) {
+								resetConversationView();
+							}
+							setSessionInfo({
+								sessionId: metadata.session_id || '',
+								userId: metadata.user_id || '',
+								agentId: metadata.agent_id || '',
+								model: metadata.model || '',
+								storagePath: metadata.storage_path || '',
+								storageRawPath: metadata.storage_raw_path || '',
+								indexPath: metadata.index_path || '',
+								indexRawPath: metadata.index_raw_path || '',
+								restored: Boolean(metadata.restored),
+							});
+							break;
 						case 'ready':
 							setIsReady(true);
 							setIsProcessing(false);
+							setIsInterrupting(false);
 							setStatusMessage('');
 							// Don't clear steps - they're now part of history
 							break;
+						case 'resume_list': {
+							const sessions = Array.isArray(metadata.sessions)
+								? metadata.sessions
+								: [];
+							setResumeSessions(sessions);
+							setResumePickerOpen(true);
+							setResumePickerLoading(false);
+							setResumePickerError('');
+							setResumeSearch('');
+							setResumeSortBy('updated_at');
+							setResumeSelectedIndex(0);
+							break;
+						}
+						case 'model_list': {
+							const models = Array.isArray(metadata.models)
+								? metadata.models
+								: [];
+							setModelOptions(models);
+							setModelPickerOpen(true);
+							setModelPickerLoading(false);
+							setModelPickerError('');
+							setModelSearch('');
+							setModelSelectedIndex(0);
+							break;
+						}
 						case 'subagent_start': {
 							const agentId = metadata.agent_id;
 							if (!agentId) break;
 
 							setSubAgentTraces(prev => {
 								const next = new Map(prev);
-								next.set(agentId, ensureSubAgentEntry(metadata, message.content));
+								next.set(
+									agentId,
+									ensureSubAgentEntry(metadata, message.content),
+								);
 								return next;
 							});
 							setActiveSubAgentId(prev => prev ?? agentId);
@@ -229,14 +364,20 @@ export default function App({yamlPath}) {
 
 							setSubAgentTraces(prev => {
 								const next = new Map(prev);
-								const existing = next.get(agentId) || ensureSubAgentEntry(metadata);
+								const existing =
+									next.get(agentId) || ensureSubAgentEntry(metadata);
 								const updated = {
 									...existing,
 									agentName: metadata.agent_name || existing.agentName,
 									displayName: metadata.display_name || existing.displayName,
-									parentAgentName: metadata.parent_agent_name ?? existing.parentAgentName,
-									parentAgentId: metadata.parent_agent_id ?? existing.parentAgentId,
-									steps: [...existing.steps, {content: message.content, metadata}],
+									parentAgentName:
+										metadata.parent_agent_name ?? existing.parentAgentName,
+									parentAgentId:
+										metadata.parent_agent_id ?? existing.parentAgentId,
+									steps: [
+										...existing.steps,
+										{content: message.content, metadata},
+									],
 									lastUpdated: Date.now(),
 								};
 								next.set(agentId, updated);
@@ -291,6 +432,20 @@ export default function App({yamlPath}) {
 							setStatusMessage(message.content);
 							setIsProcessing(true);
 							break;
+						case 'interrupted':
+							setMessages(prev => [
+								...prev,
+								{
+									role: 'assistant',
+									content: message.content,
+									steps: [...currentStepsRef.current],
+								},
+							]);
+							currentStepsRef.current = [];
+							setCurrentSteps([]);
+							setIsProcessing(false);
+							setIsInterrupting(false);
+							break;
 						case 'response':
 							// Add final response and preserve the steps with it
 							setMessages(prev => [
@@ -307,8 +462,11 @@ export default function App({yamlPath}) {
 							break;
 						case 'error':
 							setError(message.content);
+							setResumePickerLoading(false);
+							setModelPickerLoading(false);
 							setStatusMessage('');
 							setIsProcessing(false);
+							setIsInterrupting(false);
 							currentStepsRef.current = [];
 							setCurrentSteps([]);
 							break;
@@ -325,49 +483,255 @@ export default function App({yamlPath}) {
 		});
 
 		python.on('close', code => {
+			if (shutdownRequested.current) {
+				return;
+			}
 			if (code !== 0) {
 				setError(`Agent process exited with code ${code}`);
 			}
 		});
 
 		return () => {
-			if (agentProcess.current) {
-				agentProcess.current.stdin.write(
-					JSON.stringify({type: 'exit'}) + '\n',
-				);
-				agentProcess.current.kill();
+			if (!agentProcess.current) {
+				return;
 			}
+
+			shutdownRequested.current = true;
+			const proc = agentProcess.current;
+			agentProcess.current = null;
+
+			proc.stdin.write(JSON.stringify({type: 'exit'}) + '\n');
+			proc.stdin.end();
+
+			setTimeout(() => {
+				if (!proc.killed) {
+					proc.kill();
+				}
+			}, 2000);
 		};
 	}, [yamlPath]);
 
+	const filteredResumeSessions = useMemo(() => {
+		const normalizedQuery = resumeSearch.trim().toLowerCase();
+		let filtered = resumeSessions;
+		if (normalizedQuery) {
+			filtered = resumeSessions.filter(session => {
+				const id = String(session.id || '').toLowerCase();
+				const conversation = String(session.conversation || '').toLowerCase();
+				const createdAt = String(session.created_at || '').toLowerCase();
+				const updatedAt = String(session.updated_at || '').toLowerCase();
+				return (
+					id.includes(normalizedQuery) ||
+					conversation.includes(normalizedQuery) ||
+					createdAt.includes(normalizedQuery) ||
+					updatedAt.includes(normalizedQuery)
+				);
+			});
+		}
+
+		const sorted = [...filtered];
+		sorted.sort((left, right) => {
+			const leftTs = parseTimestamp(left?.[resumeSortBy]);
+			const rightTs = parseTimestamp(right?.[resumeSortBy]);
+			if (leftTs !== rightTs) {
+				return rightTs - leftTs;
+			}
+			return String(left?.id || '').localeCompare(String(right?.id || ''));
+		});
+		return sorted;
+	}, [resumeSessions, resumeSearch, resumeSortBy]);
+
+	useEffect(() => {
+		setResumeSelectedIndex(prev => {
+			if (filteredResumeSessions.length === 0) return 0;
+			if (prev < 0) return 0;
+			if (prev >= filteredResumeSessions.length)
+				return filteredResumeSessions.length - 1;
+			return prev;
+		});
+	}, [filteredResumeSessions]);
+
+	const filteredModelOptions = useMemo(() => {
+		const normalizedQuery = modelSearch.trim().toLowerCase();
+		if (!normalizedQuery) {
+			return modelOptions;
+		}
+
+		return modelOptions.filter(option => {
+			const name = String(option.name || '').toLowerCase();
+			const alias = String(option.profile_alias || '').toLowerCase();
+			return name.includes(normalizedQuery) || alias.includes(normalizedQuery);
+		});
+	}, [modelOptions, modelSearch]);
+
+	useEffect(() => {
+		setModelSelectedIndex(prev => {
+			if (filteredModelOptions.length === 0) return 0;
+			if (prev < 0) return 0;
+			if (prev >= filteredModelOptions.length)
+				return filteredModelOptions.length - 1;
+			return prev;
+		});
+	}, [filteredModelOptions]);
+
+	const requestModelPicker = () => {
+		if (!agentProcess.current) {
+			setModelPickerError('Agent process is not available.');
+			return;
+		}
+
+		setResumePickerOpen(false);
+		setModelPickerOpen(true);
+		setModelPickerLoading(true);
+		setModelPickerError('');
+		setModelSearch('');
+		setModelSelectedIndex(0);
+		setModelOptions([]);
+		agentProcess.current.stdin.write(
+			JSON.stringify({type: 'model_list'}) + '\n',
+		);
+	};
+
+	const runModelUse = modelName => {
+		if (!agentProcess.current) return;
+		const target = String(modelName || '').trim();
+		if (!target) return;
+
+		setModelPickerOpen(false);
+		setModelPickerLoading(false);
+		setModelPickerError('');
+		setIsReady(false);
+		setIsProcessing(true);
+		setError(null);
+		setStatusMessage(`Switching model to ${target}...`);
+		agentProcess.current.stdin.write(
+			JSON.stringify({type: 'model_use', model_name: target}) + '\n',
+		);
+	};
+
+	const requestResumePicker = () => {
+		if (!agentProcess.current) {
+			setResumePickerError('Agent process is not available.');
+			return;
+		}
+
+		setModelPickerOpen(false);
+		setResumePickerOpen(true);
+		setResumePickerLoading(true);
+		setResumePickerError('');
+		setResumeSearch('');
+		setResumeSortBy('updated_at');
+		setResumeSelectedIndex(0);
+		setResumeSessions([]);
+		agentProcess.current.stdin.write(
+			JSON.stringify({type: 'resume_list'}) + '\n',
+		);
+	};
+
+	const runResumeUse = sessionId => {
+		if (!agentProcess.current) return;
+		const target = String(sessionId || '').trim();
+		if (!target) return;
+
+		setResumePickerOpen(false);
+		setResumePickerLoading(false);
+		setResumePickerError('');
+		setIsReady(false);
+		setIsProcessing(true);
+		setError(null);
+		setStatusMessage('Resuming selected session...');
+		agentProcess.current.stdin.write(
+			JSON.stringify({type: 'resume_use', session_id: target}) + '\n',
+		);
+	};
+
+	const runResumeNew = () => {
+		if (!agentProcess.current) return;
+		setResumePickerOpen(false);
+		setResumePickerLoading(false);
+		setResumePickerError('');
+		setIsReady(false);
+		setIsProcessing(true);
+		setError(null);
+		setStatusMessage('Starting a fresh session...');
+		agentProcess.current.stdin.write(
+			JSON.stringify({type: 'resume_new'}) + '\n',
+		);
+	};
+
 	const handleSubmit = value => {
-		if (!value.trim() || !isReady || isProcessing) return;
+		if (!value.trim()) return;
 
 		const userMessage = value.trim();
 
-		// Check for /clear command
-		if (userMessage === "/clear" || userMessage.startsWith("/clear ")) {
-			// Clear all conversation history and reset to fresh empty state
-			setMessages([]);
+		if (isProcessing) {
+			if (userMessage === '/interrupt') {
+				if (!agentProcess.current || isInterrupting) return;
+
+				setInput('');
+				setError(null);
+				setIsInterrupting(true);
+				setStatusMessage('Interrupting current run...');
+				agentProcess.current.stdin.write(
+					JSON.stringify({type: 'interrupt'}) + '\n',
+				);
+				return;
+			}
+
+			setError(
+				'Agent is running. Press Ctrl+C or type /interrupt to stop the current run.',
+			);
 			setInput('');
-			setError(null);
-			currentStepsRef.current = [];
-			setCurrentSteps([]);
-			setSubAgentTraces(new Map());
-			setActiveSubAgentId(null);
+			return;
+		}
+
+		if (!isReady) return;
+
+		// Check for /clear command
+		if (userMessage === '/clear' || userMessage.startsWith('/clear ')) {
+			// Clear all conversation history and reset to fresh empty state
+			resetConversationView();
+			setInput('');
 
 			// Send message to Python agent
 			if (agentProcess.current) {
 				agentProcess.current.stdin.write(
-					JSON.stringify({type: 'message', content: userMessage}) + '\n',
+					JSON.stringify({type: 'clear'}) + '\n',
 				);
 			}
+			return;
+		}
+
+		if (userMessage === '/interrupt') {
+			setError('No active run to interrupt.');
+			setInput('');
+			return;
+		}
+
+		if (userMessage === '/resume') {
+			setInput('');
+			setError(null);
+			requestResumePicker();
+			return;
+		}
+
+		if (userMessage === '/model') {
+			setInput('');
+			setError(null);
+			requestModelPicker();
+			return;
+		}
+
+		if (userMessage.startsWith('/model ')) {
+			setError('Usage: /model');
+			setInput('');
 			return;
 		}
 
 		setMessages(prev => [...prev, {role: 'user', content: userMessage}]);
 		setInput('');
 		setIsReady(false);
+		setIsProcessing(true);
 		setError(null);
 		currentStepsRef.current = [];
 		setCurrentSteps([]);
@@ -380,16 +744,163 @@ export default function App({yamlPath}) {
 		}
 	};
 
+	const requestExit = () => {
+		if (!agentProcess.current) {
+			exit();
+			return;
+		}
+
+		shutdownRequested.current = true;
+		const proc = agentProcess.current;
+		agentProcess.current = null;
+		proc.stdin.write(JSON.stringify({type: 'exit'}) + '\n');
+		proc.stdin.end();
+		setTimeout(() => {
+			if (!proc.killed) {
+				proc.kill();
+			}
+		}, 2000);
+		exit();
+	};
+
 	useInput((input, key) => {
-		if (key.escape || (input === 'c' && key.ctrl)) {
-			if (agentProcess.current) {
-				agentProcess.current.stdin.write(
-					JSON.stringify({type: 'exit'}) + '\n',
-				);
-				agentProcess.current.kill();
+		if (modelPickerOpen) {
+			if (input === 'c' && key.ctrl) {
+				if (isProcessing) {
+					if (agentProcess.current && !isInterrupting) {
+						setError(null);
+						setIsInterrupting(true);
+						setStatusMessage('Interrupting current run...');
+						agentProcess.current.stdin.write(
+							JSON.stringify({type: 'interrupt'}) + '\n',
+						);
+					}
+					return;
+				}
+				requestExit();
+				return;
 			}
 
-			exit();
+			if (key.escape) {
+				setModelPickerOpen(false);
+				setModelPickerLoading(false);
+				setModelPickerError('');
+				return;
+			}
+
+			if (key.return) {
+				const selected = filteredModelOptions[modelSelectedIndex];
+				if (selected?.name) {
+					runModelUse(selected.name);
+				}
+				return;
+			}
+
+			if (key.upArrow) {
+				setModelSelectedIndex(prev => Math.max(0, prev - 1));
+				return;
+			}
+
+			if (key.downArrow) {
+				setModelSelectedIndex(prev =>
+					Math.min(Math.max(0, filteredModelOptions.length - 1), prev + 1),
+				);
+				return;
+			}
+
+			if (key.backspace || key.delete) {
+				setModelSearch(prev => prev.slice(0, -1));
+				return;
+			}
+
+			if (!key.ctrl && !key.meta && input) {
+				setModelSearch(prev => prev + input);
+			}
+			return;
+		}
+
+		if (resumePickerOpen) {
+			if (input === 'c' && key.ctrl) {
+				if (isProcessing) {
+					if (agentProcess.current && !isInterrupting) {
+						setError(null);
+						setIsInterrupting(true);
+						setStatusMessage('Interrupting current run...');
+						agentProcess.current.stdin.write(
+							JSON.stringify({type: 'interrupt'}) + '\n',
+						);
+					}
+					return;
+				}
+				requestExit();
+				return;
+			}
+
+			if (key.escape) {
+				runResumeNew();
+				return;
+			}
+
+			if (key.return) {
+				const selected = filteredResumeSessions[resumeSelectedIndex];
+				if (selected?.id) {
+					runResumeUse(selected.id);
+				} else if (!resumePickerLoading) {
+					runResumeNew();
+				}
+				return;
+			}
+
+			if (key.tab) {
+				setResumeSortBy(prev =>
+					prev === 'updated_at' ? 'created_at' : 'updated_at',
+				);
+				return;
+			}
+
+			if (key.upArrow) {
+				setResumeSelectedIndex(prev => Math.max(0, prev - 1));
+				return;
+			}
+
+			if (key.downArrow) {
+				setResumeSelectedIndex(prev =>
+					Math.min(Math.max(0, filteredResumeSessions.length - 1), prev + 1),
+				);
+				return;
+			}
+
+			if (key.backspace || key.delete) {
+				setResumeSearch(prev => prev.slice(0, -1));
+				return;
+			}
+
+			if (!key.ctrl && !key.meta && input) {
+				setResumeSearch(prev => prev + input);
+			}
+			return;
+		}
+
+		if (key.escape) {
+			requestExit();
+			return;
+		}
+
+		if (input === 'c' && key.ctrl) {
+			if (isProcessing) {
+				if (agentProcess.current && !isInterrupting) {
+					setError(null);
+					setIsInterrupting(true);
+					setStatusMessage('Interrupting current run...');
+					agentProcess.current.stdin.write(
+						JSON.stringify({type: 'interrupt'}) + '\n',
+					);
+				}
+				return;
+			}
+
+			requestExit();
+			return;
 		}
 
 		if (key.ctrl && input === 't' && subAgentTraces.size > 0) {
@@ -409,28 +920,202 @@ export default function App({yamlPath}) {
 			? subAgentTraces.get(activeSubAgentId)
 			: subAgentEntries[0] || null;
 	const activeSubAgentIndex = activeSubAgent
-		? subAgentEntries.findIndex(entry => entry.agentId === activeSubAgent.agentId)
+		? subAgentEntries.findIndex(
+				entry => entry.agentId === activeSubAgent.agentId,
+		  )
 		: -1;
 	const totalSubAgents = subAgentEntries.length;
+	const resumeSortLabel =
+		resumeSortBy === 'updated_at' ? 'Updated at' : 'Created at';
+	const resumeCreatedHeader = 'Created at';
+	const resumeUpdatedHeader = 'Updated at';
+	const resumeCreatedWidth = 14;
+	const resumeUpdatedWidth = 14;
+	const resumeHeaderRow = `${resumeCreatedHeader.padEnd(
+		resumeCreatedWidth,
+	)} ${resumeUpdatedHeader.padEnd(resumeUpdatedWidth)} Conversation`;
+	const modelHeaderRow = 'Model';
+
+	if (modelPickerOpen) {
+		return (
+			<Box flexDirection="column" height="100%" paddingX={1}>
+				<Box marginBottom={1}>
+					<Text bold>Select a model</Text>
+				</Box>
+				<Box marginBottom={1}>
+					<Text dimColor>Type to search</Text>
+					<Text> {modelSearch || ''}</Text>
+				</Box>
+				<Box marginBottom={1}>
+					<Text bold>{modelHeaderRow}</Text>
+				</Box>
+				{modelPickerLoading && (
+					<Box marginBottom={1}>
+						<Text color="yellow">
+							<Spinner type="dots" /> Loading models...
+						</Text>
+					</Box>
+				)}
+				{!modelPickerLoading && filteredModelOptions.length === 0 && (
+					<Box marginBottom={1}>
+						<Text color={modelOptions.length === 0 ? 'yellow' : 'red'}>
+							{modelOptions.length === 0
+								? 'No models available.'
+								: 'No models match your current search.'}
+						</Text>
+					</Box>
+				)}
+				{modelPickerError && (
+					<Box marginBottom={1}>
+						<Text color="red">{modelPickerError}</Text>
+					</Box>
+				)}
+				{!modelPickerLoading && filteredModelOptions.length > 0 && (
+					<Box flexDirection="column" marginBottom={1}>
+						{filteredModelOptions.map((option, index) => {
+							const selected = index === modelSelectedIndex;
+							const currentMarker = option.current ? ' [current]' : '';
+							const alias = option.profile_alias
+								? ` (profile: ${option.profile_alias})`
+								: '';
+							const row = truncateText(
+								toSingleLine(`${option.name}${currentMarker}${alias}`),
+								100,
+							);
+							return (
+								<Text
+									key={`${option.name}-${index}`}
+									color={selected ? 'cyan' : undefined}
+									wrap="truncate-end"
+								>
+									{selected ? '>' : ' '} {row}
+								</Text>
+							);
+						})}
+					</Box>
+				)}
+				<Box marginTop={1}>
+					<Text dimColor>
+						enter to switch esc to cancel ctrl + c to quit ↑/↓ to browse
+					</Text>
+				</Box>
+			</Box>
+		);
+	}
+
+	if (resumePickerOpen) {
+		return (
+			<Box flexDirection="column" height="100%" paddingX={1}>
+				<Box marginBottom={1}>
+					<Text bold>Resume a previous session</Text>
+					<Text dimColor> Sort: {resumeSortLabel}</Text>
+				</Box>
+				<Box marginBottom={1}>
+					<Text dimColor>Type to search</Text>
+					<Text> {resumeSearch || ''}</Text>
+				</Box>
+				<Box marginBottom={1}>
+					<Text bold>{resumeHeaderRow}</Text>
+				</Box>
+				{resumePickerLoading && (
+					<Box marginBottom={1}>
+						<Text color="yellow">
+							<Spinner type="dots" /> Loading sessions...
+						</Text>
+					</Box>
+				)}
+				{!resumePickerLoading && filteredResumeSessions.length === 0 && (
+					<Box marginBottom={1}>
+						<Text color={resumeSessions.length === 0 ? 'yellow' : 'red'}>
+							{resumeSessions.length === 0
+								? 'No saved sessions found. Press Esc to start new.'
+								: 'No sessions match your current search.'}
+						</Text>
+					</Box>
+				)}
+				{resumePickerError && (
+					<Box marginBottom={1}>
+						<Text color="red">{resumePickerError}</Text>
+					</Box>
+				)}
+				{!resumePickerLoading && filteredResumeSessions.length > 0 && (
+					<Box flexDirection="column" marginBottom={1}>
+						{filteredResumeSessions.map((session, index) => {
+							const selected = index === resumeSelectedIndex;
+							const createdAt = formatRelativeTime(session.created_at).padEnd(
+								resumeCreatedWidth,
+							);
+							const updatedAt = formatRelativeTime(session.updated_at).padEnd(
+								resumeUpdatedWidth,
+							);
+							const conversation = truncateText(
+								toSingleLine(session.conversation),
+								80,
+							);
+							const row = `${createdAt} ${updatedAt} ${conversation}`;
+							return (
+								<Text
+									key={session.id || `${session.index}-${index}`}
+									color={selected ? 'cyan' : undefined}
+									wrap="truncate-end"
+								>
+									{selected ? '>' : ' '} {row}
+								</Text>
+							);
+						})}
+					</Box>
+				)}
+				<Box marginTop={1}>
+					<Text dimColor>
+						enter to resume esc to start new ctrl + c to quit tab to toggle sort
+						↑/↓ to browse
+					</Text>
+				</Box>
+			</Box>
+		);
+	}
 
 	return (
 		<Box flexDirection="column" height="100%">
 			{/* Header */}
-			<Box
-				borderStyle="round"
-				borderColor="blue"
-				paddingX={1}
-				marginBottom={1}
-			>
+			<Box borderStyle="round" borderColor="blue" paddingX={1} marginBottom={1}>
 				<Text bold color="blue">
 					🤖 NexAU Agent CLI
 				</Text>
-				<Text dimColor> (Press Esc or Ctrl+C to exit)</Text>
+				<Text dimColor> (Esc exits, Ctrl+C interrupts active runs)</Text>
 			</Box>
 
 			{/* Main Content */}
 			<Box flexDirection="row" flexGrow={1} marginBottom={1} paddingX={1}>
-				<Box flexDirection="column" flexGrow={2} marginRight={activeSubAgent ? 1 : 0}>
+				<Box
+					flexDirection="column"
+					flexGrow={2}
+					marginRight={activeSubAgent ? 1 : 0}
+				>
+					{sessionInfo?.sessionId && (
+						<Box marginBottom={1} flexDirection="column">
+							<Text dimColor>
+								Session: {sessionInfo.sessionId}
+								{sessionInfo.restored ? ' (restored)' : ''}
+							</Text>
+							{sessionInfo.model && (
+								<Text dimColor>Model: {sessionInfo.model}</Text>
+							)}
+							{sessionInfo.storagePath && (
+								<Text dimColor>Store: {sessionInfo.storagePath}</Text>
+							)}
+							{sessionInfo.storageRawPath && (
+								<Text dimColor>Raw: {sessionInfo.storageRawPath}</Text>
+							)}
+							{sessionInfo.indexPath && (
+								<Text dimColor>Index: {sessionInfo.indexPath}</Text>
+							)}
+							{sessionInfo.indexRawPath && (
+								<Text dimColor>Index Raw: {sessionInfo.indexRawPath}</Text>
+							)}
+						</Box>
+					)}
+
 					{messages.map((msg, index) => (
 						<Message
 							key={index}
@@ -483,12 +1168,14 @@ export default function App({yamlPath}) {
 							</Text>
 							<Text dimColor>
 								{activeSubAgent.displayName}
-								{totalSubAgents > 1 && activeSubAgentIndex >= 0 && ` (${activeSubAgentIndex + 1}/${totalSubAgents}, press "ctrl+t" to switch)`}
+								{totalSubAgents > 1 &&
+									activeSubAgentIndex >= 0 &&
+									` (${
+										activeSubAgentIndex + 1
+									}/${totalSubAgents}, press "ctrl+t" to switch)`}
 							</Text>
 							{activeSubAgent.parentAgentName && (
-								<Text dimColor>
-									Parent: {activeSubAgent.parentAgentName}
-								</Text>
+								<Text dimColor>Parent: {activeSubAgent.parentAgentName}</Text>
 							)}
 						</Box>
 
@@ -532,10 +1219,12 @@ export default function App({yamlPath}) {
 			{/* Input Bar */}
 			<Box
 				borderStyle="round"
-				borderColor={isReady ? 'green' : 'gray'}
+				borderColor={isReady ? 'green' : isProcessing ? 'yellow' : 'gray'}
 				paddingX={1}
 			>
-				<Text color={isReady ? 'green' : 'gray'}>{isReady ? '▶' : '⏸'} </Text>
+				<Text color={isReady ? 'green' : isProcessing ? 'yellow' : 'gray'}>
+					{isReady ? '▶' : isProcessing ? '■' : '⏸'}{' '}
+				</Text>
 				<TextInput
 					value={input}
 					onChange={setInput}
@@ -543,9 +1232,13 @@ export default function App({yamlPath}) {
 					placeholder={
 						isReady
 							? 'Type your message and press Enter...'
+							: isProcessing && !isInterrupting
+							? 'Agent is running. Type /interrupt or press Ctrl+C to stop...'
+							: isInterrupting
+							? 'Interrupting current run...'
 							: 'Waiting for agent...'
 					}
-					isDisabled={!isReady || isProcessing}
+					isDisabled={(!isReady && !isProcessing) || isInterrupting}
 				/>
 			</Box>
 		</Box>

--- a/examples/code_agent/code_agent.yaml
+++ b/examples/code_agent/code_agent.yaml
@@ -26,10 +26,11 @@ llm_config: # Support environment variable replacement in YAML config
   # thinking:
   #   type: "adaptive"
 
-  api_type: openai_responses
-  reasoning:
-    effort: "medium"
-    summary: "detailed"
+  # api_type: openai_responses
+  # reasoning:
+  #   effort: "medium"
+  #   summary: "detailed"
+  api_type: openai_chat_completion
 
 sub_agents:
   - name: explore

--- a/nexau/cli/agent_runner.py
+++ b/nexau/cli/agent_runner.py
@@ -19,14 +19,21 @@ This script runs the NexAU agent and communicates via stdin/stdout.
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
+import logging
 import os
 import sys
+import threading
+import traceback
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nexau.archs.main_sub.agent import Agent
+from nexau.archs.main_sub.agent_context import GlobalStorage
 from nexau.archs.main_sub.config import (
     ConfigError,
 )
@@ -39,10 +46,15 @@ from nexau.archs.main_sub.execution.hooks import (
     AfterToolHookResult,
 )
 from nexau.archs.main_sub.utils import load_yaml_with_vars
+from nexau.archs.session.models.serialization_utils import sanitize_for_serialization
 from nexau.cli.cli_subagent_adapter import attach_cli_to_agent
+from nexau.core.messages import Message, Role
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
     from nexau.archs.main_sub.agent import Agent
+    from nexau.archs.main_sub.execution.stop_result import StopResult
+
+logger = logging.getLogger(__name__)
 
 
 # Ensure the active project root is importable.
@@ -67,12 +79,716 @@ def get_date():
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
+_stdout_lock = threading.Lock()
+_CLI_TRANSIENT_STORAGE_KEYS = {"tracer", "skill_registry"}
+
+
 def send_message(msg_type, content, metadata=None):
     """Send a JSON message to stdout."""
     message = {"type": msg_type, "content": content}
     if metadata:
         message["metadata"] = metadata
-    print(json.dumps(message), flush=True)
+    with _stdout_lock:
+        print(json.dumps(message), flush=True)
+
+
+def _resolve_cli_snapshot_dir() -> Path:
+    env_dir = os.environ.get("NEXAU_CLI_STATE_DIR")
+    candidates = []
+    if env_dir:
+        candidates.append(Path(env_dir).expanduser())
+
+    candidates.extend(
+        [
+            Path(_project_root) / ".nexau" / "cli-sessions",
+            Path.home() / ".nexau" / "cli-sessions",
+            Path("/tmp") / "nexau" / "cli-sessions",
+        ]
+    )
+
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            return candidate
+        except OSError:
+            continue
+
+    raise OSError("Unable to create a writable CLI session snapshot directory")
+
+
+class CliSessionStore:
+    """Multi-session snapshot store for CLI resume (JSON/JSONL only)."""
+
+    @dataclass(frozen=True)
+    class SnapshotPaths:
+        file_path: Path
+        readable_path: Path
+
+    def __init__(self, *, config_path: Path, user_id: str):
+        self.config_path = config_path.resolve()
+        self.user_id = user_id
+        self.base_dir = _resolve_cli_snapshot_dir()
+        self.store_key = self._build_store_key()
+        self.store_dir = self.base_dir / self.store_key
+        self.store_dir.mkdir(parents=True, exist_ok=True)
+        self.sessions_dir = self.store_dir / "sessions"
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self.manifest_path = self.store_dir / "manifest.json"
+        self.manifest_readable_path = self.manifest_path
+        legacy_file_name = f"{self.store_key}.json"
+        self.legacy_file_path = self.base_dir / legacy_file_name
+        self.legacy_readable_path = self.legacy_file_path
+        self._jsonl_history_cursor: dict[str, int] = {}
+
+    @staticmethod
+    def _slugify(value: str, *, default: str) -> str:
+        safe_value = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in value).strip("-_")
+        return safe_value or default
+
+    def _build_store_key(self) -> str:
+        base_name = self.config_path.stem or "agent"
+        safe_name = self._slugify(base_name, default="agent")
+        digest = hashlib.sha1(f"{self.config_path}:{self.user_id}".encode()).hexdigest()[:10]
+        return f"{safe_name}-{digest}"
+
+    def snapshot_paths(self, session_id: str) -> SnapshotPaths:
+        manifest = self._load_manifest()
+        for entry in manifest.get("sessions", []):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("session_id") != session_id:
+                continue
+            existing_paths = self._manifest_entry_paths(entry)
+            if existing_paths is not None:
+                return existing_paths
+
+        session_slug = self._slugify(session_id, default="session")
+        if len(session_slug) > 64:
+            digest = hashlib.sha1(session_id.encode()).hexdigest()[:12]
+            session_slug = f"{session_slug[:48]}-{digest}"
+        session_dir = self.sessions_dir / session_slug
+        session_dir.mkdir(parents=True, exist_ok=True)
+        file_path = session_dir / "messages.jsonl"
+        checkpoint_path = session_dir / "session_checkpoint.json"
+        return self.SnapshotPaths(file_path=file_path, readable_path=checkpoint_path)
+
+    def _read_jsonl_snapshot(self, path: Path) -> dict[str, Any] | None:
+        if not path.exists():
+            return None
+
+        latest_checkpoint: dict[str, Any] | None = None
+        session_meta_payload: dict[str, Any] | None = None
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    event = json.loads(line)
+                    if not isinstance(event, dict):
+                        continue
+                    event_type = event.get("type")
+                    payload = event.get("payload")
+                    if event_type == "session_meta" and isinstance(payload, dict):
+                        session_meta_payload = payload
+                        continue
+                    if event_type == "session_checkpoint" and isinstance(payload, dict):
+                        latest_checkpoint = payload
+                        continue
+                    # Compatibility path: a pure snapshot object stored as one jsonl line.
+                    if "history" in event and "session_id" in event:
+                        latest_checkpoint = event
+        except Exception as exc:
+            logger.warning("Failed to parse CLI session jsonl snapshot from %s: %s", path, exc)
+            return None
+
+        if latest_checkpoint is None:
+            return None
+
+        snapshot = dict(latest_checkpoint)
+        if session_meta_payload:
+            snapshot.setdefault("session_id", session_meta_payload.get("id", ""))
+            snapshot.setdefault("agent_config_path", session_meta_payload.get("agent_config_path", str(self.config_path)))
+            snapshot.setdefault("user_id", session_meta_payload.get("user_id", self.user_id))
+        return snapshot
+
+    def _read_snapshot_file(self, path: Path) -> dict[str, Any] | None:
+        if path.suffix == ".jsonl":
+            return self._read_jsonl_snapshot(path)
+        return self._read_json_file(path)
+
+    def _read_checkpoint_file(self, path: Path) -> dict[str, Any] | None:
+        if not path.exists() or path.suffix == ".jsonl":
+            return None
+        data = self._read_json_file(path)
+        if not isinstance(data, dict):
+            return None
+
+        if data.get("type") == "session_checkpoint" and isinstance(data.get("payload"), dict):
+            return data["payload"]
+
+        if "history" in data and "session_id" in data:
+            return data
+        return None
+
+    def _extract_text_blocks(self, content: Any) -> str:
+        if not isinstance(content, list):
+            return ""
+        texts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "text":
+                continue
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                texts.append(text)
+        return "".join(texts).strip()
+
+    def _build_message_events(
+        self,
+        message_payload: dict[str, Any],
+        *,
+        timestamp: str,
+        message_index: int,
+    ) -> list[dict[str, Any]]:
+        role = message_payload.get("role")
+        if not isinstance(role, str):
+            return []
+
+        content = message_payload.get("content")
+        blocks = content if isinstance(content, list) else []
+        text = self._extract_text_blocks(blocks)
+        message_id = message_payload.get("id", "")
+        created_at = message_payload.get("created_at", "")
+        base_payload = {
+            "message_id": message_id,
+            "message_index": message_index,
+            "role": role,
+            "created_at": created_at,
+        }
+
+        events: list[dict[str, Any]] = []
+
+        if role in {Role.USER.value, Role.FRAMEWORK.value}:
+            events.append(
+                {
+                    "timestamp": timestamp,
+                    "type": "user_message",
+                    "payload": {
+                        **base_payload,
+                        "text": text,
+                    },
+                }
+            )
+            return events
+
+        if role == Role.ASSISTANT.value:
+            events.append(
+                {
+                    "timestamp": timestamp,
+                    "type": "agent_message",
+                    "payload": {
+                        **base_payload,
+                        "text": text,
+                    },
+                }
+            )
+            for block in blocks:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                events.append(
+                    {
+                        "timestamp": timestamp,
+                        "type": "function_call",
+                        "payload": {
+                            **base_payload,
+                            "call_id": block.get("id", ""),
+                            "name": block.get("name", ""),
+                            "arguments": block.get("input", {}),
+                            "raw_arguments": block.get("raw_input"),
+                        },
+                    }
+                )
+            return events
+
+        if role == Role.TOOL.value:
+            for block in blocks:
+                if not isinstance(block, dict) or block.get("type") != "tool_result":
+                    continue
+                events.append(
+                    {
+                        "timestamp": timestamp,
+                        "type": "function_result",
+                        "payload": {
+                            **base_payload,
+                            "tool_use_id": block.get("tool_use_id", ""),
+                            "content": block.get("content", ""),
+                            "is_error": bool(block.get("is_error", False)),
+                        },
+                    }
+                )
+            return events
+
+        # Keep non-standard roles observable in log stream.
+        if text:
+            events.append(
+                {
+                    "timestamp": timestamp,
+                    "type": "message",
+                    "payload": {
+                        **base_payload,
+                        "text": text,
+                    },
+                }
+            )
+        return events
+
+    def _latest_history_count_in_jsonl(self, path: Path, *, checkpoint_path: Path) -> int:
+        cache_key = str(path.resolve())
+        cached = self._jsonl_history_cursor.get(cache_key)
+        if cached is not None:
+            return cached
+
+        checkpoint = self._read_checkpoint_file(checkpoint_path)
+        if isinstance(checkpoint, dict):
+            history = checkpoint.get("history")
+            if isinstance(history, list):
+                history_count = len(history)
+                self._jsonl_history_cursor[cache_key] = history_count
+                return history_count
+
+        history_count = 0
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        event = json.loads(line)
+                        if not isinstance(event, dict):
+                            continue
+                        payload = event.get("payload")
+                        if isinstance(payload, dict):
+                            message_index = payload.get("message_index")
+                            if isinstance(message_index, int):
+                                history_count = max(history_count, message_index + 1)
+            except Exception as exc:
+                logger.warning("Failed to infer history cursor from %s: %s", path, exc)
+                history_count = 0
+
+        self._jsonl_history_cursor[cache_key] = history_count
+        return history_count
+
+    def _write_checkpoint_file(self, path: Path, *, payload: dict[str, Any], timestamp: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        checkpoint = {
+            "timestamp": timestamp,
+            "type": "session_checkpoint",
+            "payload": payload,
+        }
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(checkpoint, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+
+    def _append_jsonl_snapshot(
+        self,
+        path: Path,
+        *,
+        checkpoint_path: Path,
+        payload: dict[str, Any],
+        agent: Agent,
+    ) -> None:
+        now = datetime.now().isoformat()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        cache_key = str(path.resolve())
+        previous_history_count = self._latest_history_count_in_jsonl(path, checkpoint_path=checkpoint_path)
+        history_payload = payload.get("history") if isinstance(payload.get("history"), list) else []
+
+        start_index = previous_history_count
+        if previous_history_count > len(history_payload):
+            start_index = 0
+
+        with path.open("a", encoding="utf-8") as f:
+            if path.stat().st_size == 0:
+                session_meta = {
+                    "timestamp": now,
+                    "type": "session_meta",
+                    "payload": {
+                        "id": payload.get("session_id", ""),
+                        "timestamp": now,
+                        "cwd": _project_root,
+                        "source": "nexau-cli",
+                        "agent_config_path": str(self.config_path),
+                        "user_id": self.user_id,
+                        "agent_id": agent.agent_id,
+                        "model": getattr(agent.config.llm_config, "model", ""),
+                    },
+                }
+                f.write(json.dumps(session_meta, ensure_ascii=False) + "\n")
+
+            for message_index, history_item in enumerate(history_payload[start_index:], start=start_index):
+                if not isinstance(history_item, dict):
+                    continue
+                for event in self._build_message_events(
+                    history_item,
+                    timestamp=now,
+                    message_index=message_index,
+                ):
+                    f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+            checkpoint_ref = {
+                "timestamp": now,
+                "type": "checkpoint_ref",
+                "payload": {
+                    "checkpoint_path": str(checkpoint_path),
+                    "history_count": len(history_payload),
+                },
+            }
+            f.write(json.dumps(checkpoint_ref, ensure_ascii=False) + "\n")
+        self._write_checkpoint_file(checkpoint_path, payload=payload, timestamp=now)
+        self._jsonl_history_cursor[cache_key] = len(history_payload)
+
+    def _read_json_file(self, path: Path) -> dict[str, Any] | None:
+        if not path.exists():
+            return None
+
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception as exc:
+            logger.warning("Failed to load CLI session snapshot from %s: %s", path, exc)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        return data
+
+    def _load_manifest(self) -> dict[str, Any]:
+        data = self._read_json_file(self.manifest_path)
+        if not data:
+            legacy_snapshot = self._load_legacy_snapshot()
+            if legacy_snapshot is None:
+                return self._empty_manifest()
+            legacy_entry = self._snapshot_entry(
+                payload=legacy_snapshot,
+                paths=self.SnapshotPaths(
+                    file_path=self.legacy_file_path,
+                    readable_path=self.legacy_readable_path,
+                ),
+            )
+            return {
+                **self._empty_manifest(),
+                "updated_at": legacy_snapshot.get("updated_at", ""),
+                "current_session_id": legacy_entry["session_id"],
+                "sessions": [legacy_entry],
+            }
+
+        if data.get("agent_config_path") != str(self.config_path):
+            return self._empty_manifest()
+        if data.get("user_id") != self.user_id:
+            return self._empty_manifest()
+
+        sessions = data.get("sessions")
+        if not isinstance(sessions, list):
+            sessions = []
+
+        return {
+            "version": data.get("version", 2),
+            "agent_config_path": str(self.config_path),
+            "user_id": self.user_id,
+            "updated_at": data.get("updated_at", ""),
+            "current_session_id": data.get("current_session_id", "") or "",
+            "sessions": [entry for entry in sessions if isinstance(entry, dict)],
+        }
+
+    def _empty_manifest(self) -> dict[str, Any]:
+        return {
+            "version": 2,
+            "agent_config_path": str(self.config_path),
+            "user_id": self.user_id,
+            "updated_at": "",
+            "current_session_id": "",
+            "sessions": [],
+        }
+
+    def _load_legacy_snapshot(self) -> dict[str, Any] | None:
+        data = self._read_json_file(self.legacy_file_path)
+        if not data:
+            return None
+        if data.get("agent_config_path") != str(self.config_path):
+            return None
+        if data.get("user_id") != self.user_id:
+            return None
+        return data
+
+    def _manifest_entry_paths(self, entry: dict[str, Any]) -> SnapshotPaths | None:
+        json_path = entry.get("json_path")
+        readable_path = entry.get("readable_path")
+        if not isinstance(json_path, str):
+            return None
+        if not isinstance(readable_path, str) or not readable_path:
+            readable_path = json_path
+        return self.SnapshotPaths(
+            file_path=(self.store_dir / json_path).resolve(),
+            readable_path=(self.store_dir / readable_path).resolve(),
+        )
+
+    def _snapshot_entry(self, *, payload: dict[str, Any], paths: SnapshotPaths) -> dict[str, Any]:
+        history = payload.get("history")
+        history_payload = history if isinstance(history, list) else []
+        preview = self._build_preview(history_payload)
+        first_user_input = self._build_first_user_input(history_payload)
+        created_at = payload.get("created_at")
+        if not isinstance(created_at, str) or not created_at:
+            created_at = payload.get("updated_at", "")
+        last_context = payload.get("last_context")
+        cwd = ""
+        if isinstance(last_context, dict):
+            cwd_value = last_context.get("working_directory")
+            if isinstance(cwd_value, str):
+                cwd = cwd_value
+        return {
+            "session_id": payload.get("session_id", ""),
+            "agent_id": payload.get("agent_id", ""),
+            "created_at": created_at,
+            "updated_at": payload.get("updated_at", ""),
+            "cwd": cwd,
+            "message_count": len(history_payload),
+            "preview": preview,
+            "first_user_input": first_user_input,
+            "json_path": os.path.relpath(paths.file_path, self.store_dir),
+            "readable_path": os.path.relpath(paths.readable_path, self.store_dir),
+        }
+
+    def _build_preview(self, history_payload: list[Any]) -> str:
+        for item in reversed(history_payload):
+            if not isinstance(item, dict):
+                continue
+            try:
+                message = Message.model_validate(item)
+            except Exception:
+                continue
+            preview = message.get_text_content().strip()
+            if preview:
+                preview = " ".join(preview.split())
+                if len(preview) > 120:
+                    preview = preview[:117] + "..."
+                return preview
+        return ""
+
+    def _build_first_user_input(self, history_payload: list[Any]) -> str:
+        for item in history_payload:
+            if not isinstance(item, dict):
+                continue
+            try:
+                message = Message.model_validate(item)
+            except Exception:
+                continue
+            if message.role not in {Role.USER, Role.FRAMEWORK}:
+                continue
+            content = message.get_text_content().strip()
+            if content:
+                content = " ".join(content.split())
+                if len(content) > 120:
+                    content = content[:117] + "..."
+                return content
+        return ""
+
+    def _sort_entries(self, entries: list[dict[str, Any]], *, current_session_id: str = "") -> list[dict[str, Any]]:
+        def sort_key(entry: dict[str, Any]) -> tuple[bool, str]:
+            session_id = entry.get("session_id", "")
+            updated_at = entry.get("updated_at", "") or ""
+            return (session_id == current_session_id, updated_at)
+
+        return sorted(entries, key=sort_key, reverse=True)
+
+    def _write_manifest(self, manifest: dict[str, Any]) -> None:
+        sessions = manifest.get("sessions", [])
+        current_session_id = manifest.get("current_session_id", "") or ""
+        normalized_manifest = {
+            "version": 2,
+            "agent_config_path": str(self.config_path),
+            "user_id": self.user_id,
+            "updated_at": manifest.get("updated_at", ""),
+            "current_session_id": current_session_id,
+            "sessions": self._sort_entries(
+                [entry for entry in sessions if isinstance(entry, dict)],
+                current_session_id=current_session_id,
+            ),
+        }
+
+        with self.manifest_path.open("w", encoding="utf-8") as f:
+            json.dump(normalized_manifest, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        self._write_readable_manifest(normalized_manifest)
+
+    def _write_readable_manifest(self, manifest: dict[str, Any]) -> None:
+        _ = manifest
+        return
+
+    def load_current(self) -> dict[str, Any] | None:
+        manifest = self._load_manifest()
+        current_session_id = manifest.get("current_session_id")
+        if not isinstance(current_session_id, str) or not current_session_id:
+            target_cwd = _project_root
+            ordered_entries = self._sort_entries(
+                [entry for entry in manifest.get("sessions", []) if isinstance(entry, dict)],
+                current_session_id="",
+            )
+            cwd_entries = [
+                entry
+                for entry in ordered_entries
+                if isinstance(entry.get("cwd"), str) and entry.get("cwd") == target_cwd
+            ]
+            candidate_entries = cwd_entries if cwd_entries else ordered_entries
+            for entry in candidate_entries:
+                session_id = entry.get("session_id")
+                if isinstance(session_id, str) and session_id:
+                    return self.load_session(session_id)
+            return None
+        return self.load_session(current_session_id)
+
+    def load_session(self, session_id: str) -> dict[str, Any] | None:
+        manifest = self._load_manifest()
+        for entry in manifest.get("sessions", []):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("session_id") != session_id:
+                continue
+            paths = self._manifest_entry_paths(entry)
+            if paths is None:
+                continue
+            snapshot = self._read_checkpoint_file(paths.readable_path)
+            if snapshot is None:
+                snapshot = self._read_snapshot_file(paths.file_path)
+            if snapshot is not None:
+                return snapshot
+
+        legacy_snapshot = self._load_legacy_snapshot()
+        if legacy_snapshot is not None and legacy_snapshot.get("session_id") == session_id:
+            return legacy_snapshot
+
+        return None
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        manifest = self._load_manifest()
+        current_session_id = manifest.get("current_session_id", "") or ""
+        sessions = []
+        for entry in manifest.get("sessions", []):
+            if not isinstance(entry, dict):
+                continue
+            paths = self._manifest_entry_paths(entry)
+            session_id = entry.get("session_id")
+            if not isinstance(session_id, str) or not session_id:
+                continue
+            sessions.append(
+                {
+                    **entry,
+                    "created_at": entry.get("created_at", "") or entry.get("updated_at", "") or "",
+                    "first_user_input": entry.get("first_user_input", "") or "",
+                    "current": session_id == current_session_id,
+                    "file_path": str(paths.file_path) if paths else "",
+                    "readable_path": str(paths.readable_path) if paths else "",
+                }
+            )
+
+        return self._sort_entries(sessions, current_session_id=current_session_id)
+
+    def set_current_session(self, session_id: str) -> None:
+        manifest = self._load_manifest()
+        sessions = manifest.get("sessions", [])
+        if not any(isinstance(entry, dict) and entry.get("session_id") == session_id for entry in sessions):
+            legacy_snapshot = self._load_legacy_snapshot()
+            if legacy_snapshot is None or legacy_snapshot.get("session_id") != session_id:
+                raise KeyError(f"Unknown session id: {session_id}")
+            sessions = [
+                self._snapshot_entry(
+                    payload=legacy_snapshot,
+                    paths=self.SnapshotPaths(
+                        file_path=self.legacy_file_path,
+                        readable_path=self.legacy_readable_path,
+                    ),
+                )
+            ]
+
+        manifest["updated_at"] = datetime.now().isoformat()
+        manifest["current_session_id"] = session_id
+        manifest["sessions"] = sessions
+        self._write_manifest(manifest)
+
+    def save(
+        self,
+        *,
+        agent: Agent,
+        history: list[Message],
+        last_context: dict[str, Any] | None = None,
+    ) -> None:
+        serializable_storage = {
+            key: value
+            for key, value in sanitize_for_serialization(agent.global_storage.to_dict()).items()
+            if key not in _CLI_TRANSIENT_STORAGE_KEYS
+        }
+        non_system_history = [msg for msg in history if msg.role != Role.SYSTEM]
+        session_id = getattr(agent, "_session_id", None)
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("Agent session_id is required for CLI snapshot persistence")
+
+        paths = self.snapshot_paths(session_id)
+        payload = {
+            "version": 2,
+            "agent_config_path": str(self.config_path),
+            "user_id": self.user_id,
+            "agent_id": agent.agent_id,
+            "session_id": session_id,
+            "updated_at": datetime.now().isoformat(),
+            "history": [msg.model_dump(mode="json", exclude_none=True) for msg in non_system_history],
+            "global_storage": serializable_storage,
+            "last_context": sanitize_for_serialization(last_context or {}),
+        }
+
+        manifest = self._load_manifest()
+        existing_entry = next(
+            (
+                entry
+                for entry in manifest.get("sessions", [])
+                if isinstance(entry, dict) and entry.get("session_id") == session_id
+            ),
+            None,
+        )
+        existing_created_at = existing_entry.get("created_at") if isinstance(existing_entry, dict) else ""
+        payload["created_at"] = existing_created_at if isinstance(existing_created_at, str) and existing_created_at else payload["updated_at"]
+
+        if paths.file_path.suffix == ".jsonl":
+            self._append_jsonl_snapshot(
+                paths.file_path,
+                checkpoint_path=paths.readable_path,
+                payload=payload,
+                agent=agent,
+            )
+        else:
+            with paths.file_path.open("w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+                f.write("\n")
+
+        self._write_readable_snapshot(payload, paths=paths)
+
+        updated_entry = self._snapshot_entry(payload=payload, paths=paths)
+        existing_sessions = [
+            entry
+            for entry in manifest.get("sessions", [])
+            if isinstance(entry, dict) and entry.get("session_id") != session_id
+        ]
+        manifest["updated_at"] = payload["updated_at"]
+        manifest["current_session_id"] = session_id
+        manifest["sessions"] = [updated_entry, *existing_sessions]
+        self._write_manifest(manifest)
+
+    def _write_readable_snapshot(self, payload: dict[str, Any], *, paths: SnapshotPaths) -> None:
+        _ = (payload, paths)
+        return
 
 
 def create_cli_progress_hook():
@@ -242,156 +958,812 @@ def create_cli_tool_hook():
     return tool_hook
 
 
+class CliAgentRuntime:
+    """Run the CLI agent in a background worker thread so control messages stay responsive."""
+
+    def __init__(self, config_path: Path):
+        self.config_path = config_path
+        self.user_id = os.environ.get("NEXAU_CLI_USER_ID", "cli_user")
+        self._session_store = CliSessionStore(config_path=config_path, user_id=self.user_id)
+        self._requested_session_id = os.environ.get("NEXAU_CLI_SESSION_ID") or None
+        self._restored_snapshot = (
+            self._session_store.load_session(self._requested_session_id)
+            if self._requested_session_id
+            else self._session_store.load_current()
+        )
+        self.initial_session_id = (
+            self._requested_session_id
+            or (self._restored_snapshot or {}).get("session_id")
+            or None
+        )
+        self._agent: Agent | None = None
+        self._run_thread: threading.Thread | None = None
+        self._state_lock = threading.Lock()
+        self._interrupt_requested = False
+        self._last_stop_result: StopResult | None = None
+        self._llm_override: dict[str, str] | None = None
+
+        self._cli_progress_hook = create_cli_progress_hook()
+        self._cli_tool_hook = create_cli_tool_hook()
+
+    def start(self) -> None:
+        self._activate_agent(restored_snapshot=self._restored_snapshot, session_id=self.initial_session_id)
+        send_message("status", "Agent loaded successfully")
+        self._emit_session_event(restored=self._restored_snapshot is not None)
+        self._persist_state()
+        send_message("ready", "Agent is ready for input", metadata=self._session_metadata())
+
+    def shutdown(self) -> None:
+        if self.is_busy():
+            try:
+                self.interrupt(force=True, timeout=5.0)
+            except Exception:
+                logger.exception("Failed to interrupt active run during shutdown")
+
+        if self._agent is not None:
+            self._persist_state()
+            self._agent.sync_cleanup()
+            self._agent = None
+
+    def is_busy(self) -> bool:
+        with self._state_lock:
+            return self._run_thread is not None and self._run_thread.is_alive()
+
+    def start_message(self, user_message: str) -> None:
+        with self._state_lock:
+            if self._run_thread is not None and self._run_thread.is_alive():
+                raise RuntimeError("Agent is already processing a request")
+            if self._agent is None:
+                raise RuntimeError("Agent is not initialized")
+
+            self._interrupt_requested = False
+            self._last_stop_result = None
+            self._run_thread = threading.Thread(
+                target=self._run_message_sync,
+                args=(user_message,),
+                name="nexau-cli-run",
+                daemon=True,
+            )
+            self._run_thread.start()
+
+    def interrupt(self, *, force: bool = True, timeout: float = 10.0) -> None:
+        with self._state_lock:
+            if self._agent is None:
+                raise RuntimeError("Agent is not initialized")
+            if self._run_thread is None or not self._run_thread.is_alive():
+                raise RuntimeError("No active run to interrupt")
+            run_thread = self._run_thread
+            self._interrupt_requested = True
+
+        self._last_stop_result = asyncio.run(self._agent.stop(force=force, timeout=timeout))
+        run_thread.join(timeout + 5.0)
+        if run_thread.is_alive():
+            logger.warning("Timed out waiting for interrupted run thread to finish")
+
+    def clear(self) -> None:
+        self.new_session()
+
+    def new_session(self) -> None:
+        if self.is_busy():
+            raise RuntimeError("Cannot start a fresh session while the agent is processing. Interrupt it first.")
+
+        send_message("status", "Starting a fresh session...")
+        self._activate_agent(restored_snapshot=None, session_id=None)
+        self._restored_snapshot = None
+        self._persist_state()
+        self._emit_session_event(restored=False, reset_ui=True)
+        response_text = "Started a fresh session. Previous sessions are still available via /resume."
+        send_message("response", response_text)
+        send_message("ready", "", metadata=self._session_metadata())
+
+    def use_session(self, session_id: str) -> None:
+        if self.is_busy():
+            raise RuntimeError("Cannot switch sessions while the agent is processing. Interrupt it first.")
+
+        snapshot = self._session_store.load_session(session_id)
+        if snapshot is None:
+            raise RuntimeError(f"Unknown session id: {session_id}")
+
+        send_message("status", f"Switching to session {session_id}...")
+        self._activate_agent(
+            restored_snapshot=snapshot,
+            session_id=snapshot.get("session_id") if isinstance(snapshot.get("session_id"), str) else session_id,
+        )
+        self._persist_state()
+        self._emit_session_event(
+            restored=True,
+            reset_ui=True,
+            content=f"Session ready: {self._agent._session_id}",
+        )
+        send_message("response", f"Switched to session {self._agent._session_id}.")
+        send_message("ready", "", metadata=self._session_metadata())
+
+    def _resolve_resume_target_session_id(self) -> str:
+        sessions = self._session_store.list_sessions()
+        if not sessions:
+            raise RuntimeError("No saved sessions found. Use /resume to start or select a session.")
+
+        current_entry = next((entry for entry in sessions if entry.get("current")), None)
+        if current_entry and isinstance(current_entry.get("session_id"), str):
+            return current_entry["session_id"]
+
+        newest = sessions[0].get("session_id")
+        if isinstance(newest, str) and newest:
+            return newest
+
+        raise RuntimeError("No resumable session found.")
+
+    def resume(self) -> None:
+        session_id = self._resolve_resume_target_session_id()
+        self.use_session(session_id)
+
+    def format_session_list(self) -> str:
+        if self.is_busy():
+            raise RuntimeError("Cannot list sessions while the agent is processing. Interrupt it first.")
+
+        self._persist_state()
+        sessions = self._session_store.list_sessions()
+        current_session_id = getattr(self._agent, "_session_id", None) or ""
+        if not sessions:
+            return (
+                "No saved sessions yet.\n"
+                f"Raw index: {self._session_store.manifest_path}\n"
+                "Use /resume to choose or start a session."
+            )
+
+        lines = [
+            f"Saved sessions for {self.config_path.name} / {self.user_id}:",
+            f"Raw index: {self._session_store.manifest_path}",
+            "",
+        ]
+
+        for index, entry in enumerate(sessions, start=1):
+            session_id = entry.get("session_id", "")
+            current_marker = " [current]" if session_id == current_session_id else ""
+            updated_at = entry.get("updated_at", "") or "unknown"
+            created_at = entry.get("created_at", "") or updated_at
+            message_count = entry.get("message_count", 0)
+            lines.append(
+                f"{index}. {session_id}{current_marker} | created {created_at} | updated {updated_at} | messages {message_count}"
+            )
+            preview = entry.get("preview", "")
+            if isinstance(preview, str) and preview:
+                lines.append(f"  {preview}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _extract_first_user_input_from_history(history_payload: Any) -> str:
+        if not isinstance(history_payload, list):
+            return ""
+
+        for item in history_payload:
+            if not isinstance(item, dict):
+                continue
+            try:
+                message = Message.model_validate(item)
+            except Exception:
+                continue
+            if message.role not in {Role.USER, Role.FRAMEWORK}:
+                continue
+            content = message.get_text_content().strip()
+            if content:
+                content = " ".join(content.split())
+                if len(content) > 120:
+                    content = content[:117] + "..."
+                return content
+        return ""
+
+    @staticmethod
+    def _resume_conversation_preview(entry: dict[str, Any], *, fallback_first_user_input: str = "") -> str:
+        if fallback_first_user_input.strip():
+            return fallback_first_user_input.strip()
+
+        first_user_input = entry.get("first_user_input", "")
+        if isinstance(first_user_input, str) and first_user_input.strip():
+            return first_user_input.strip()
+
+        preview = entry.get("preview", "")
+        if isinstance(preview, str) and preview.strip():
+            return preview.strip()
+
+        cwd = entry.get("cwd", "")
+        if isinstance(cwd, str) and cwd.strip():
+            return cwd.strip()
+
+        session_id = entry.get("session_id", "")
+        if isinstance(session_id, str):
+            return session_id
+        return ""
+
+    def list_resume_sessions(self) -> list[dict[str, Any]]:
+        if self.is_busy():
+            raise RuntimeError("Cannot list sessions while the agent is processing. Interrupt it first.")
+
+        self._persist_state()
+        sessions = self._session_store.list_sessions()
+        structured: list[dict[str, Any]] = []
+        for index, entry in enumerate(sessions, start=1):
+            session_id = entry.get("session_id", "")
+            if not isinstance(session_id, str) or not session_id:
+                continue
+
+            first_user_input = entry.get("first_user_input", "")
+            if not isinstance(first_user_input, str) or not first_user_input.strip():
+                snapshot = self._session_store.load_session(session_id)
+                if isinstance(snapshot, dict):
+                    first_user_input = self._extract_first_user_input_from_history(snapshot.get("history"))
+                else:
+                    first_user_input = ""
+
+            created_at = entry.get("created_at", "") or entry.get("updated_at", "") or ""
+            updated_at = entry.get("updated_at", "") or ""
+            structured.append(
+                {
+                    "index": index,
+                    "id": session_id,
+                    "created_at": created_at,
+                    "updated_at": updated_at,
+                    "conversation": self._resume_conversation_preview(
+                        entry,
+                        fallback_first_user_input=first_user_input,
+                    ),
+                    "current": bool(entry.get("current", False)),
+                }
+            )
+
+        return structured
+
+    def handle_session_command(self, command_text: str) -> None:
+        parts = command_text.split()
+        if len(parts) == 1 or parts[1] in {"help", "-h", "--help"}:
+            send_message(
+                "response",
+                "Session commands:\n/session list\n/session new\n/session use <session_id>\n/resume",
+            )
+            send_message("ready", "", metadata=self._session_metadata())
+            return
+
+        action = parts[1]
+        if action == "list" and len(parts) == 2:
+            send_message("response", self.format_session_list())
+            send_message("ready", "", metadata=self._session_metadata())
+            return
+        if action == "new" and len(parts) == 2:
+            self.new_session()
+            return
+        if action == "use" and len(parts) == 3:
+            self.use_session(parts[2])
+            return
+
+        raise RuntimeError("Usage: /session list | /session new | /session use <session_id>")
+
+    def handle_resume_command(self, command_text: str) -> None:
+        parts = command_text.split()
+        if len(parts) == 1:
+            self.resume()
+            return
+
+        raise RuntimeError("Usage: /resume")
+
+    def _resolve_model_inventory(self) -> tuple[str, tuple[str, ...]]:
+        if self._agent is None or self._agent.config.llm_config is None:
+            return "", ()
+
+        llm_config = self._agent.config.llm_config
+        current_model = llm_config.model or ""
+        available_models = tuple(llm_config.list_available_models() if hasattr(llm_config, "list_available_models") else ())
+        if current_model and current_model not in available_models:
+            available_models = (current_model, *available_models)
+        return current_model, available_models
+
+    def _discover_llm_profiles(self) -> dict[str, dict[str, str]]:
+        """Discover profile-style env configs like NEX_MODEL/NEX_BASE_URL/NEX_API_KEY."""
+        profiles: dict[str, dict[str, str]] = {}
+        for env_name, model_value in os.environ.items():
+            if not env_name.endswith("_MODEL"):
+                continue
+            prefix = env_name[: -len("_MODEL")]
+            if prefix in {"LLM", "SUMMARY", "OPENAI", "MODEL"}:
+                continue
+            if not model_value:
+                continue
+
+            base_url = os.getenv(f"{prefix}_BASE_URL")
+            api_key = os.getenv(f"{prefix}_API_KEY")
+            if not base_url or not api_key:
+                continue
+
+            alias = prefix.lower()
+            profiles[alias] = {
+                "alias": alias,
+                "model": model_value,
+                "base_url": base_url,
+                "api_key": api_key,
+            }
+        return profiles
+
+    @staticmethod
+    def _merge_models_with_profiles(
+        available_models: tuple[str, ...],
+        profiles: dict[str, dict[str, str]],
+    ) -> tuple[str, ...]:
+        merged: list[str] = [model for model in available_models if isinstance(model, str) and model]
+        for profile in profiles.values():
+            model_name = profile.get("model")
+            if not isinstance(model_name, str) or not model_name:
+                continue
+            if model_name in merged:
+                continue
+            merged.append(model_name)
+        return tuple(merged)
+
+    def format_model_list(self) -> str:
+        if self.is_busy():
+            raise RuntimeError("Cannot list models while the agent is processing. Interrupt it first.")
+
+        profiles = self._discover_llm_profiles()
+        current_model, available_models = self._resolve_model_inventory()
+        available_models = self._merge_models_with_profiles(available_models, profiles)
+        if not available_models and not current_model:
+            return "No model configured."
+
+        if not available_models and current_model:
+            available_models = (current_model,)
+
+        lines = ["Available models:"]
+        for idx, model_name in enumerate(available_models, start=1):
+            marker = " [current]" if model_name == current_model else ""
+            lines.append(f"{idx}. {model_name}{marker}")
+        return "\n".join(lines)
+
+    def list_model_options(self) -> list[dict[str, Any]]:
+        if self.is_busy():
+            raise RuntimeError("Cannot list models while the agent is processing. Interrupt it first.")
+
+        current_model, available_models = self._resolve_model_inventory()
+        profiles = self._discover_llm_profiles()
+        available_models = self._merge_models_with_profiles(available_models, profiles)
+        if not available_models and current_model:
+            available_models = (current_model,)
+
+        profile_by_model = {profile["model"]: profile for profile in profiles.values()}
+        options: list[dict[str, Any]] = []
+        for idx, model_name in enumerate(available_models, start=1):
+            profile = profile_by_model.get(model_name)
+            options.append(
+                {
+                    "index": idx,
+                    "name": model_name,
+                    "current": model_name == current_model,
+                    "profile_alias": profile.get("alias") if profile else "",
+                }
+            )
+        return options
+
+    def switch_model(self, target: str) -> None:
+        if self.is_busy():
+            raise RuntimeError("Cannot switch model while the agent is processing. Interrupt it first.")
+        if self._agent is None:
+            raise RuntimeError("Agent is not initialized")
+        if self._agent.config.llm_config is None:
+            raise RuntimeError("Agent LLM config is not initialized")
+
+        candidate = target.strip()
+        if not candidate:
+            raise RuntimeError("Usage: /model use <index|model_name>")
+
+        current_model, available_models_raw = self._resolve_model_inventory()
+        current_base_url = self._agent.config.llm_config.base_url or ""
+        current_api_key = self._agent.config.llm_config.api_key or ""
+        profiles = self._discover_llm_profiles()
+        available_models = self._merge_models_with_profiles(available_models_raw, profiles)
+        profile_by_model = {profile["model"]: profile for profile in profiles.values()}
+
+        selected_profile: dict[str, str] | None = None
+        if candidate.isdigit():
+            if not available_models:
+                raise RuntimeError("No available models configured.")
+            index = int(candidate)
+            if index < 1 or index > len(available_models):
+                raise RuntimeError(f"Model index must be between 1 and {len(available_models)}")
+            selected_model = available_models[index - 1]
+            selected_profile = profile_by_model.get(selected_model)
+        else:
+            selected_profile = profiles.get(candidate.lower())
+            selected_model = selected_profile["model"] if selected_profile else candidate
+            if available_models and selected_model not in available_models and selected_model not in profile_by_model:
+                raise RuntimeError(f"Unknown model: {selected_model}")
+            if selected_profile is None:
+                selected_profile = profile_by_model.get(selected_model)
+
+        target_runtime = {
+            "model": selected_model,
+            "base_url": selected_profile["base_url"] if selected_profile else current_base_url,
+            "api_key": selected_profile["api_key"] if selected_profile else current_api_key,
+        }
+        if not target_runtime["base_url"] or not target_runtime["api_key"]:
+            raise RuntimeError("Target model is missing base_url or api_key")
+
+        if (
+            selected_model == current_model
+            and target_runtime["base_url"] == current_base_url
+            and target_runtime["api_key"] == current_api_key
+        ):
+            send_message("response", f"Model already in use: {selected_model}")
+            send_message("ready", "", metadata=self._session_metadata())
+            return
+
+        current_session_id = getattr(self._agent, "_session_id", None)
+        if not isinstance(current_session_id, str) or not current_session_id:
+            raise RuntimeError("Current session is not initialized")
+
+        self._persist_state()
+        snapshot = self._session_store.load_session(current_session_id)
+        if snapshot is None:
+            raise RuntimeError("Failed to load current session snapshot for model switch")
+
+        profile_suffix = f" (profile: {selected_profile['alias']})" if selected_profile else ""
+        send_message("status", f"Switching model to {selected_model}{profile_suffix}...")
+        self._llm_override = target_runtime
+        self._activate_agent(restored_snapshot=snapshot, session_id=current_session_id)
+        self._persist_state()
+        send_message("response", f"Switched model to {selected_model}{profile_suffix}.")
+        send_message("ready", "", metadata=self._session_metadata())
+
+    def handle_model_command(self, command_text: str) -> None:
+        parts = command_text.split()
+        if len(parts) == 1:
+            send_message("response", self.format_model_list())
+            send_message("ready", "", metadata=self._session_metadata())
+            return
+
+        raise RuntimeError("Usage: /model")
+
+    def _session_metadata(self) -> dict[str, Any]:
+        session_id = getattr(self._agent, "_session_id", None) or ""
+        agent_id = getattr(self._agent, "agent_id", None) or ""
+        current_model, available_models = self._resolve_model_inventory()
+        metadata = {
+            "user_id": self.user_id,
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "model": current_model,
+            "index_path": str(self._session_store.manifest_path),
+            "index_raw_path": str(self._session_store.manifest_path),
+        }
+        if available_models:
+            metadata["available_models"] = list(available_models)
+        if session_id:
+            snapshot_paths = self._session_store.snapshot_paths(session_id)
+            metadata["storage_path"] = str(snapshot_paths.file_path)
+            metadata["storage_raw_path"] = str(snapshot_paths.file_path)
+        return metadata
+
+    def _emit_session_event(
+        self,
+        *,
+        restored: bool,
+        reset_ui: bool = False,
+        content: str | None = None,
+    ) -> None:
+        session_id = getattr(self._agent, "_session_id", None) or ""
+        send_message(
+            "session",
+            content or f"Session ready: {session_id}",
+            metadata={
+                **self._session_metadata(),
+                "restored": restored,
+                "reset_ui": reset_ui,
+            },
+        )
+
+    def _handle_subagent_event(self, event_type: str, payload: dict) -> None:
+        event_mapping = {
+            "start": ("subagent_start", "message"),
+            "complete": ("subagent_complete", "result"),
+            "error": ("subagent_error", "error"),
+        }
+
+        if event_type not in event_mapping:
+            return
+
+        message_type, content_field = event_mapping[event_type]
+        content = payload.get(content_field, "")
+        send_message(message_type, content, metadata=payload)
+
+    def _build_agent_from_config(self, *, session_id: str | None) -> Agent:
+        raw_config = load_yaml_with_vars(str(self.config_path))
+        if not raw_config:
+            raise ConfigError(
+                f"Empty or invalid configuration file: {self.config_path}",
+            )
+
+        if not isinstance(raw_config, dict):
+            raise ConfigError(
+                f"Invalid configuration type in {self.config_path}; expected mapping",
+            )
+
+        normalized_config = normalize_agent_config_dict(raw_config)
+
+        if self._llm_override:
+            llm_config_raw = normalized_config.get("llm_config")
+            if not isinstance(llm_config_raw, dict):
+                raise ConfigError("llm_config is required and must be a mapping in agent configuration")
+            llm_config_raw["model"] = self._llm_override["model"]
+            llm_config_raw["base_url"] = self._llm_override["base_url"]
+            llm_config_raw["api_key"] = self._llm_override["api_key"]
+
+        existing_model_hooks = list(normalized_config.get("after_model_hooks", []))
+        existing_tool_hooks = list(normalized_config.get("after_tool_hooks", []))
+
+        normalized_config["after_model_hooks"] = [self._cli_progress_hook] + existing_model_hooks
+        normalized_config["after_tool_hooks"] = [self._cli_tool_hook] + existing_tool_hooks
+
+        builder = AgentConfigBuilder(normalized_config, self.config_path.parent)
+        agent_config = (
+            builder.build_core_properties()
+            .build_llm_config()
+            .build_mcp_servers()
+            .build_hooks()
+            .build_tracers()
+            .build_tools()
+            .build_sub_agents()
+            .build_skills()
+            .build_system_prompt_path()
+            .build_sandbox()
+            .get_agent_config()
+        )
+        restored_storage = self._build_restored_global_storage()
+        restored_agent_id = None if self._restored_snapshot is None else self._restored_snapshot.get("agent_id")
+        return Agent(
+            config=agent_config,
+            agent_id=restored_agent_id if isinstance(restored_agent_id, str) and restored_agent_id else None,
+            global_storage=restored_storage,
+            user_id=self.user_id,
+            session_id=session_id,
+        )
+
+    def _activate_agent(self, *, restored_snapshot: dict[str, Any] | None, session_id: str | None) -> None:
+        if self._agent is not None:
+            self._persist_state()
+            self._agent.sync_cleanup()
+
+        self._restored_snapshot = restored_snapshot
+        self._agent = self._build_agent_from_config(session_id=session_id)
+        self._restore_agent_state()
+        attach_cli_to_agent(
+            self._agent,
+            self._cli_progress_hook,
+            self._cli_tool_hook,
+            self._handle_subagent_event,
+        )
+
+    def _build_restored_global_storage(self) -> GlobalStorage | None:
+        if self._restored_snapshot is None:
+            return None
+
+        stored = self._restored_snapshot.get("global_storage")
+        if not isinstance(stored, dict):
+            return None
+
+        restored = GlobalStorage()
+        restored.update(stored)
+        return restored
+
+    def _restore_agent_state(self) -> None:
+        if self._agent is None or self._restored_snapshot is None:
+            return
+
+        history_payload = self._restored_snapshot.get("history")
+        if isinstance(history_payload, list):
+            restored_history = []
+            for item in history_payload:
+                if not isinstance(item, dict):
+                    continue
+                try:
+                    restored_history.append(Message.model_validate(item))
+                except Exception as exc:
+                    logger.warning("Skipping invalid persisted message in CLI session snapshot: %s", exc)
+            if restored_history:
+                self._agent.history = restored_history
+
+        last_context = self._restored_snapshot.get("last_context")
+        if isinstance(last_context, dict):
+            self._agent._last_context = last_context
+
+    def _persist_state(self) -> None:
+        if self._agent is None:
+            return
+
+        try:
+            self._session_store.save(
+                agent=self._agent,
+                history=list(self._agent.history),
+                last_context=getattr(self._agent, "_last_context", {}) or {},
+            )
+        except Exception as exc:
+            logger.warning("Failed to persist CLI session snapshot: %s", exc)
+
+    def _rebuild_agent_from_current_session(self) -> None:
+        if self._agent is None:
+            return
+
+        current_session_id = getattr(self._agent, "_session_id", None)
+        if not isinstance(current_session_id, str) or not current_session_id:
+            return
+
+        snapshot = self._session_store.load_session(current_session_id)
+        if snapshot is None:
+            logger.warning("Failed to reload interrupted session snapshot for %s", current_session_id)
+            return
+
+        self._activate_agent(restored_snapshot=snapshot, session_id=current_session_id)
+
+    def _run_message_sync(self, user_message: str) -> None:
+        if self._agent is None:
+            raise RuntimeError("Agent is not initialized")
+
+        send_message("step", "Processing request...", metadata={"type": "start"})
+
+        sandbox = self._agent.sandbox_manager.instance
+
+        try:
+            response = self._agent.run(
+                message=user_message,
+                context={
+                    "date": get_date(),
+                    "username": os.getenv("USER", "user"),
+                    "working_directory": str(sandbox.work_dir if sandbox else os.getcwd()),
+                    "env_content": {
+                        "date": get_date(),
+                        "username": os.getenv("USER", "user"),
+                        "working_directory": str(sandbox.work_dir if sandbox else os.getcwd()),
+                    },
+                },
+            )
+
+            if not self._interrupt_requested:
+                send_message("step", "Request completed", metadata={"type": "complete"})
+                final_response = response[0] if isinstance(response, tuple) else response
+                send_message("response", final_response)
+        except Exception as e:
+            if not self._interrupt_requested:
+                send_message("error", f"{str(e)}\n{traceback.format_exc()}")
+        finally:
+            self._persist_state()
+            interrupted_result = self._last_stop_result
+            was_interrupted = interrupted_result is not None
+
+            with self._state_lock:
+                self._run_thread = None
+                self._interrupt_requested = False
+                self._last_stop_result = None
+
+            if was_interrupted:
+                self._rebuild_agent_from_current_session()
+                send_message(
+                    "interrupted",
+                    "Current run interrupted. Session preserved.",
+                    metadata={
+                        **self._session_metadata(),
+                        "stop_reason": interrupted_result.stop_reason.name,
+                        "message_count": len(interrupted_result.messages),
+                    },
+                )
+
+            send_message("ready", "", metadata=self._session_metadata())
+
+
 def main():
     if len(sys.argv) < 2:
         send_message("error", "No agent configuration file provided")
         sys.exit(1)
 
     yaml_path = sys.argv[1]
+    runtime: CliAgentRuntime | None = None
 
     try:
-        # Load agent from YAML configuration
         send_message("status", "Loading agent configuration...")
-
-        # Create our CLI progress hooks
-        cli_progress_hook = create_cli_progress_hook()
-        cli_tool_hook = create_cli_tool_hook()
-
-        # Helper to forward sub-agent lifecycle events to the CLI
-        def handle_subagent_event(event_type: str, payload: dict):
-            event_mapping = {
-                "start": ("subagent_start", "message"),
-                "complete": ("subagent_complete", "result"),
-                "error": ("subagent_error", "error"),
-            }
-
-            if event_type not in event_mapping:
-                return
-
-            message_type, content_field = event_mapping[event_type]
-            content = payload.get(content_field, "")
-            send_message(message_type, content, metadata=payload)
 
         config_path = Path(yaml_path)
         _ensure_config_dir_on_sys_path(config_path)
+        runtime = CliAgentRuntime(config_path)
+        runtime.start()
 
-        def build_agent_from_config() -> Agent:
-            raw_config = load_yaml_with_vars(str(config_path))
-            if not raw_config:
-                raise ConfigError(
-                    f"Empty or invalid configuration file: {config_path}",
-                )
-
-            if not isinstance(raw_config, dict):
-                raise ConfigError(
-                    f"Invalid configuration type in {config_path}; expected mapping",
-                )
-
-            normalized_config = normalize_agent_config_dict(raw_config)
-
-            existing_model_hooks = list(normalized_config.get("after_model_hooks", []))
-            existing_tool_hooks = list(normalized_config.get("after_tool_hooks", []))
-
-            normalized_config["after_model_hooks"] = [cli_progress_hook] + existing_model_hooks
-            normalized_config["after_tool_hooks"] = [cli_tool_hook] + existing_tool_hooks
-
-            builder = AgentConfigBuilder(normalized_config, config_path.parent)
-            agent_config = (
-                builder.build_core_properties()
-                .build_llm_config()
-                .build_mcp_servers()
-                .build_hooks()
-                .build_tracers()
-                .build_tools()
-                .build_sub_agents()
-                .build_skills()
-                .build_system_prompt_path()
-                .build_sandbox()
-                .get_agent_config()
-            )
-            return Agent(config=agent_config)
-
-        agent = build_agent_from_config()
-
-        attach_cli_to_agent(agent, cli_progress_hook, cli_tool_hook, handle_subagent_event)
-
-        send_message("status", "Agent loaded successfully")
-        send_message("ready", "Agent is ready for input")
-
-        # Process messages from stdin
-        for line in sys.stdin:
-            line = line.strip()
+        for raw_line in sys.stdin:
+            line = raw_line.strip()
             if not line:
                 continue
 
             try:
                 data = json.loads(line)
+                message_type = data.get("type")
 
-                if data.get("type") == "exit":
+                if message_type == "exit":
                     send_message("status", "Shutting down...")
+                    runtime.shutdown()
                     break
 
-                if data.get("type") == "message":
+                if message_type == "interrupt":
+                    send_message("status", "Interrupting current run...")
+                    runtime.interrupt(force=True, timeout=10.0)
+                    continue
+
+                if message_type == "clear":
+                    runtime.clear()
+                    continue
+
+                if message_type == "resume_list":
+                    send_message("resume_list", "", metadata={"sessions": runtime.list_resume_sessions()})
+                    continue
+
+                if message_type == "resume_use":
+                    session_id = data.get("session_id", "")
+                    if not isinstance(session_id, str) or not session_id.strip():
+                        raise RuntimeError("resume_use requires a non-empty session_id")
+                    runtime.use_session(session_id.strip())
+                    continue
+
+                if message_type == "resume_new":
+                    runtime.new_session()
+                    continue
+
+                if message_type == "model_list":
+                    send_message("model_list", "", metadata={"models": runtime.list_model_options()})
+                    continue
+
+                if message_type == "model_use":
+                    model_name = data.get("model_name", "")
+                    if not isinstance(model_name, str) or not model_name.strip():
+                        raise RuntimeError("model_use requires a non-empty model_name")
+                    runtime.switch_model(model_name.strip())
+                    continue
+
+                if message_type == "message":
                     user_message = data.get("content", "")
                     if not user_message:
                         continue
 
-                    # Check for /clear command
-                    if user_message.strip() == "/clear":
-                        send_message("status", "Re-initializing agent...")
-
-                        agent = build_agent_from_config()
-
-                        attach_cli_to_agent(agent, cli_progress_hook, cli_tool_hook, handle_subagent_event)
-
-                        send_message("status", "Agent re-initialized successfully")
-                        send_message("response", "Agent has been re-initialized. Conversation history cleared.")
-                        send_message("ready", "")
+                    stripped_message = user_message.strip()
+                    if stripped_message == "/clear":
+                        runtime.clear()
+                        continue
+                    if stripped_message == "/interrupt":
+                        send_message("status", "Interrupting current run...")
+                        runtime.interrupt(force=True, timeout=10.0)
+                        continue
+                    if stripped_message.startswith("/resume"):
+                        runtime.handle_resume_command(stripped_message)
+                        continue
+                    if stripped_message.startswith("/session"):
+                        runtime.handle_session_command(stripped_message)
+                        continue
+                    if stripped_message.startswith("/model"):
+                        runtime.handle_model_command(stripped_message)
                         continue
 
-                    send_message("step", "Processing request...", metadata={"type": "start"})
+                    runtime.start_message(user_message)
+                    continue
 
-                    sandbox = agent.sandbox_manager.instance
-
-                    # Run the agent
-                    response = agent.run(
-                        message=user_message,
-                        context={
-                            "date": get_date(),
-                            "username": os.getenv("USER", "user"),
-                            "working_directory": str(sandbox.work_dir if sandbox else os.getcwd()),
-                            "env_content": {
-                                "date": get_date(),
-                                "username": os.getenv("USER", "user"),
-                                "working_directory": str(sandbox.work_dir if sandbox else os.getcwd()),
-                            },
-                        },
-                    )
-
-                    send_message("step", "Request completed", metadata={"type": "complete"})
-                    send_message("response", response)
-                    send_message("ready", "")
-
+                send_message("error", f"Unsupported message type: {message_type}")
             except ConfigError as e:
                 send_message("error", str(e))
-                send_message("ready", "")
+                send_message("ready", "", metadata=runtime._session_metadata())
             except json.JSONDecodeError:
                 send_message("error", f"Invalid JSON received: {line}")
             except Exception as e:
-                import traceback
-
-                error_details = traceback.format_exc()
-                send_message("error", f"{str(e)}\n{error_details}")
-                send_message("ready", "")
+                send_message("error", f"{str(e)}\n{traceback.format_exc()}")
+                send_message("ready", "", metadata=runtime._session_metadata())
 
     except ConfigError as e:
+        if runtime is not None:
+            runtime.shutdown()
         send_message("error", str(e))
         sys.exit(1)
     except Exception as e:
-        import traceback
-
-        error_details = traceback.format_exc()
-        send_message("error", f"Failed to load agent: {str(e)}\n{error_details}")
+        if runtime is not None:
+            runtime.shutdown()
+        send_message("error", f"Failed to load agent: {str(e)}\n{traceback.format_exc()}")
         sys.exit(1)
 
 

--- a/tests/unit/test_cli_agent_runner_model.py
+++ b/tests/unit/test_cli_agent_runner_model.py
@@ -1,0 +1,200 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for /model runtime commands in CLI agent runner."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nexau.cli.agent_runner import CliAgentRuntime
+
+
+def _build_runtime_stub() -> CliAgentRuntime:
+    runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+    runtime.is_busy = Mock(return_value=False)
+    runtime._session_metadata = Mock(return_value={"session_id": "sess-1"})
+    runtime.format_model_list = Mock(return_value="Available models:\n1. gpt-4o-mini [current]\n2. gpt-4.1")
+    runtime._resolve_model_inventory = Mock(return_value=("gpt-4o-mini", ("gpt-4o-mini", "gpt-4.1")))
+    runtime.list_model_options = Mock(
+        return_value=[
+            {"index": 1, "name": "gpt-4o-mini", "current": True, "profile_alias": ""},
+            {"index": 2, "name": "gpt-4.1", "current": False, "profile_alias": "nex"},
+        ]
+    )
+    runtime.switch_model = Mock()
+    return runtime
+
+
+class TestModelCommands:
+    def test_handle_model_command_default(self):
+        runtime = _build_runtime_stub()
+        with patch("nexau.cli.agent_runner.send_message") as send_message:
+            runtime.handle_model_command("/model")
+
+        send_message.assert_any_call("response", "Available models:\n1. gpt-4o-mini [current]\n2. gpt-4.1")
+        send_message.assert_any_call("ready", "", metadata={"session_id": "sess-1"})
+        runtime.format_model_list.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "command_text",
+        [
+            "/model list",
+            "/model current",
+            "/model use 2",
+            "/model bad",
+        ],
+    )
+    def test_handle_model_command_invalid_usage(self, command_text):
+        runtime = _build_runtime_stub()
+        with pytest.raises(RuntimeError, match="Usage: /model"):
+            runtime.handle_model_command(command_text)
+
+    def test_list_model_options_returns_structured_items(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime.is_busy = Mock(return_value=False)
+        runtime._resolve_model_inventory = Mock(return_value=("gpt-4o-mini", ("gpt-4o-mini", "gpt-4.1")))
+        runtime._discover_llm_profiles = Mock(
+            return_value={
+                "nex": {
+                    "alias": "nex",
+                    "model": "gpt-4.1",
+                    "base_url": "https://nex.example.com/v1",
+                    "api_key": "nex-key",
+                }
+            }
+        )
+
+        result = runtime.list_model_options()
+
+        assert result == [
+            {"index": 1, "name": "gpt-4o-mini", "current": True, "profile_alias": ""},
+            {"index": 2, "name": "gpt-4.1", "current": False, "profile_alias": "nex"},
+        ]
+
+    def test_list_model_options_includes_profile_only_models(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime.is_busy = Mock(return_value=False)
+        runtime._resolve_model_inventory = Mock(return_value=("kimi-model", ("kimi-model",)))
+        runtime._discover_llm_profiles = Mock(
+            return_value={
+                "nex": {
+                    "alias": "nex",
+                    "model": "nex-model",
+                    "base_url": "https://nex.example.com/v1",
+                    "api_key": "nex-key",
+                }
+            }
+        )
+
+        result = runtime.list_model_options()
+
+        assert result == [
+            {"index": 1, "name": "kimi-model", "current": True, "profile_alias": ""},
+            {"index": 2, "name": "nex-model", "current": False, "profile_alias": "nex"},
+        ]
+
+    def test_switch_model_updates_override_and_rebuilds_agent(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime.is_busy = Mock(return_value=False)
+        runtime._resolve_model_inventory = Mock(return_value=("gpt-4o-mini", ("gpt-4o-mini", "gpt-4.1")))
+        runtime._discover_llm_profiles = Mock(
+            return_value={
+                "nex": {
+                    "alias": "nex",
+                    "model": "gpt-4.1",
+                    "base_url": "https://nex.example.com/v1",
+                    "api_key": "nex-key",
+                }
+            }
+        )
+        runtime._persist_state = Mock()
+        runtime._activate_agent = Mock()
+        runtime._session_metadata = Mock(return_value={"session_id": "sess-1"})
+        runtime._session_store = Mock()
+        runtime._session_store.load_session.return_value = {"session_id": "sess-1"}
+        runtime._agent = Mock()
+        runtime._agent._session_id = "sess-1"
+        runtime._agent.config = Mock()
+        runtime._agent.config.llm_config = Mock()
+        runtime._agent.config.llm_config.base_url = "https://kimi.example.com/v1"
+        runtime._agent.config.llm_config.api_key = "kimi-key"
+        runtime._llm_override = None
+
+        with patch("nexau.cli.agent_runner.send_message") as send_message:
+            runtime.switch_model("2")
+
+        assert runtime._llm_override == {
+            "model": "gpt-4.1",
+            "base_url": "https://nex.example.com/v1",
+            "api_key": "nex-key",
+        }
+        runtime._activate_agent.assert_called_once_with(
+            restored_snapshot={"session_id": "sess-1"},
+            session_id="sess-1",
+        )
+        send_message.assert_any_call("status", "Switching model to gpt-4.1 (profile: nex)...")
+        send_message.assert_any_call("response", "Switched model to gpt-4.1 (profile: nex).")
+        send_message.assert_any_call("ready", "", metadata={"session_id": "sess-1"})
+
+    def test_switch_model_rejects_unknown_model_name(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime.is_busy = Mock(return_value=False)
+        runtime._resolve_model_inventory = Mock(return_value=("gpt-4o-mini", ("gpt-4o-mini", "gpt-4.1")))
+        runtime._discover_llm_profiles = Mock(return_value={})
+        runtime._agent = Mock()
+        runtime._agent._session_id = "sess-1"
+        runtime._agent.config = Mock()
+        runtime._agent.config.llm_config = Mock()
+        runtime._agent.config.llm_config.base_url = "https://kimi.example.com/v1"
+        runtime._agent.config.llm_config.api_key = "kimi-key"
+
+        with pytest.raises(RuntimeError, match="Unknown model: unknown-model"):
+            runtime.switch_model("unknown-model")
+
+    def test_switch_model_by_profile_alias_switches_model_and_credentials(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime.is_busy = Mock(return_value=False)
+        runtime._resolve_model_inventory = Mock(return_value=("kimi-model", ("kimi-model", "nex-model")))
+        runtime._discover_llm_profiles = Mock(
+            return_value={
+                "nex": {
+                    "alias": "nex",
+                    "model": "nex-model",
+                    "base_url": "https://nex.example.com/v1",
+                    "api_key": "nex-key",
+                }
+            }
+        )
+        runtime._persist_state = Mock()
+        runtime._activate_agent = Mock()
+        runtime._session_metadata = Mock(return_value={"session_id": "sess-1"})
+        runtime._session_store = Mock()
+        runtime._session_store.load_session.return_value = {"session_id": "sess-1"}
+        runtime._agent = Mock()
+        runtime._agent._session_id = "sess-1"
+        runtime._agent.config = Mock()
+        runtime._agent.config.llm_config = Mock()
+        runtime._agent.config.llm_config.base_url = "https://kimi.example.com/v1"
+        runtime._agent.config.llm_config.api_key = "kimi-key"
+        runtime._llm_override = None
+
+        with patch("nexau.cli.agent_runner.send_message"):
+            runtime.switch_model("nex")
+
+        assert runtime._llm_override == {
+            "model": "nex-model",
+            "base_url": "https://nex.example.com/v1",
+            "api_key": "nex-key",
+        }

--- a/tests/unit/test_cli_agent_runner_resume.py
+++ b/tests/unit/test_cli_agent_runner_resume.py
@@ -1,0 +1,311 @@
+# Copyright (c) Nex-AGI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for /resume runtime commands in CLI agent runner."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nexau.cli.agent_runner import CliAgentRuntime, CliSessionStore
+
+
+def _build_runtime_stub() -> CliAgentRuntime:
+    runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+    runtime._session_metadata = Mock(return_value={"session_id": "sess-1"})
+    runtime.resume = Mock()
+    return runtime
+
+
+class TestResumeCommands:
+    def test_handle_resume_command_default(self):
+        runtime = _build_runtime_stub()
+        runtime.handle_resume_command("/resume")
+        runtime.resume.assert_called_once_with()
+
+    def test_handle_resume_command_invalid_usage(self):
+        runtime = _build_runtime_stub()
+        with pytest.raises(RuntimeError, match="Usage: /resume"):
+            runtime.handle_resume_command("/resume 2")
+
+    def test_resolve_resume_target_prefers_current(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime._session_store = Mock()
+        runtime._session_store.list_sessions.return_value = [
+            {"session_id": "local_1", "current": False},
+            {"session_id": "local_2", "current": True},
+        ]
+
+        assert runtime._resolve_resume_target_session_id() == "local_2"
+
+    def test_resolve_resume_target_falls_back_to_latest(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime._session_store = Mock()
+        runtime._session_store.list_sessions.return_value = [
+            {"session_id": "local_1", "current": False},
+            {"session_id": "local_2", "current": False},
+        ]
+
+        assert runtime._resolve_resume_target_session_id() == "local_1"
+
+    def test_resolve_resume_target_no_sessions_raises(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime._session_store = Mock()
+        runtime._session_store.list_sessions.return_value = []
+
+        with pytest.raises(RuntimeError, match="No saved sessions found"):
+            runtime._resolve_resume_target_session_id()
+
+    def test_list_resume_sessions_returns_structured_items(self):
+        runtime = CliAgentRuntime.__new__(CliAgentRuntime)
+        runtime.is_busy = Mock(return_value=False)
+        runtime._persist_state = Mock()
+        runtime._session_store = Mock()
+        runtime._session_store.list_sessions.return_value = [
+            {
+                "session_id": "local_1",
+                "created_at": "2026-04-08T08:00:00",
+                "updated_at": "2026-04-08T09:00:00",
+                "first_user_input": "first hello",
+                "preview": "hello world",
+                "current": True,
+            },
+            {
+                "session_id": "local_2",
+                "updated_at": "2026-04-08T07:00:00",
+                "cwd": "/repo/project",
+                "preview": "",
+                "current": False,
+            },
+        ]
+        runtime._session_store.load_session.side_effect = (
+            lambda session_id: {
+                "history": [
+                    {"role": "user", "content": [{"type": "text", "text": "earliest user input"}]},
+                    {"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+                ]
+            }
+            if session_id == "local_2"
+            else None
+        )
+
+        result = runtime.list_resume_sessions()
+
+        assert result == [
+            {
+                "index": 1,
+                "id": "local_1",
+                "created_at": "2026-04-08T08:00:00",
+                "updated_at": "2026-04-08T09:00:00",
+                "conversation": "first hello",
+                "current": True,
+            },
+            {
+                "index": 2,
+                "id": "local_2",
+                "created_at": "2026-04-08T07:00:00",
+                "updated_at": "2026-04-08T07:00:00",
+                "conversation": "earliest user input",
+                "current": False,
+            },
+        ]
+
+
+class TestSessionStoreLoadCurrent:
+    def test_load_current_uses_current_session_id_when_present(self):
+        store = CliSessionStore.__new__(CliSessionStore)
+        store._load_manifest = Mock(return_value={"current_session_id": "local_current", "sessions": []})
+        store.load_session = Mock(return_value={"session_id": "local_current"})
+
+        snapshot = store.load_current()
+
+        assert snapshot == {"session_id": "local_current"}
+        store.load_session.assert_called_once_with("local_current")
+
+    def test_load_current_falls_back_to_latest_same_cwd(self):
+        store = CliSessionStore.__new__(CliSessionStore)
+        store._load_manifest = Mock(
+            return_value={
+                "current_session_id": "",
+                "sessions": [
+                    {"session_id": "other_cwd", "updated_at": "2026-04-08T10:00:00", "cwd": "/tmp/other"},
+                    {"session_id": "same_cwd", "updated_at": "2026-04-08T11:00:00", "cwd": "/repo/current"},
+                ],
+            }
+        )
+        store._sort_entries = Mock(
+            return_value=[
+                {"session_id": "same_cwd", "updated_at": "2026-04-08T11:00:00", "cwd": "/repo/current"},
+                {"session_id": "other_cwd", "updated_at": "2026-04-08T10:00:00", "cwd": "/tmp/other"},
+            ]
+        )
+        store.load_session = Mock(return_value={"session_id": "same_cwd"})
+
+        with patch("nexau.cli.agent_runner._project_root", "/repo/current"):
+            snapshot = store.load_current()
+
+        assert snapshot == {"session_id": "same_cwd"}
+        store.load_session.assert_called_once_with("same_cwd")
+
+
+class TestSessionStoreJsonlEvents:
+    def test_snapshot_paths_use_per_session_directory_layout(self, tmp_path):
+        config_path = tmp_path / "agent.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+        store = CliSessionStore(config_path=config_path, user_id="cli_user")
+
+        paths = store.snapshot_paths("local_20260408_100000_000001")
+
+        assert paths.file_path.name == "messages.jsonl"
+        assert paths.readable_path.name == "session_checkpoint.json"
+        assert paths.file_path.parent == paths.readable_path.parent
+
+    def test_append_jsonl_snapshot_writes_message_events(self, tmp_path):
+        config_path = tmp_path / "agent.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+        store = CliSessionStore(config_path=config_path, user_id="cli_user")
+
+        jsonl_path = tmp_path / "sessions" / "rollout.jsonl"
+        checkpoint_path = tmp_path / "sessions" / "session_checkpoint.json"
+        agent = SimpleNamespace(
+            agent_id="agent-1",
+            config=SimpleNamespace(llm_config=SimpleNamespace(model="gpt-test")),
+        )
+
+        payload = {
+            "session_id": "local_1",
+            "updated_at": "2026-04-08T10:00:00",
+            "history": [
+                {
+                    "id": "m-user-1",
+                    "role": "user",
+                    "created_at": "2026-04-08T10:00:00",
+                    "content": [{"type": "text", "text": "hello"}],
+                },
+                {
+                    "id": "m-assistant-1",
+                    "role": "assistant",
+                    "created_at": "2026-04-08T10:00:01",
+                    "content": [
+                        {"type": "text", "text": "calling tool"},
+                        {"type": "tool_use", "id": "call-1", "name": "search", "input": {"q": "nexau"}},
+                    ],
+                },
+                {
+                    "id": "m-tool-1",
+                    "role": "tool",
+                    "created_at": "2026-04-08T10:00:02",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call-1",
+                            "content": "ok",
+                            "is_error": False,
+                        }
+                    ],
+                },
+            ],
+            "global_storage": {},
+            "last_context": {},
+        }
+
+        store._append_jsonl_snapshot(
+            jsonl_path,
+            checkpoint_path=checkpoint_path,
+            payload=payload,
+            agent=agent,
+        )
+
+        events = [json.loads(line) for line in jsonl_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        event_types = [event.get("type") for event in events]
+
+        assert "session_meta" in event_types
+        assert "user_message" in event_types
+        assert "agent_message" in event_types
+        assert "function_call" in event_types
+        assert "function_result" in event_types
+        assert "session_checkpoint" not in event_types
+        assert event_types[-1] == "checkpoint_ref"
+
+        checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        assert checkpoint["type"] == "session_checkpoint"
+        assert checkpoint["payload"]["session_id"] == "local_1"
+
+    def test_append_jsonl_snapshot_appends_only_new_message_events(self, tmp_path):
+        config_path = tmp_path / "agent.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+        store = CliSessionStore(config_path=config_path, user_id="cli_user")
+
+        jsonl_path = tmp_path / "sessions" / "rollout.jsonl"
+        checkpoint_path = tmp_path / "sessions" / "session_checkpoint.json"
+        agent = SimpleNamespace(
+            agent_id="agent-1",
+            config=SimpleNamespace(llm_config=SimpleNamespace(model="gpt-test")),
+        )
+
+        first_payload = {
+            "session_id": "local_1",
+            "updated_at": "2026-04-08T10:00:00",
+            "history": [
+                {
+                    "id": "m-user-1",
+                    "role": "user",
+                    "created_at": "2026-04-08T10:00:00",
+                    "content": [{"type": "text", "text": "hello"}],
+                }
+            ],
+            "global_storage": {},
+            "last_context": {},
+        }
+        second_payload = {
+            **first_payload,
+            "updated_at": "2026-04-08T10:01:00",
+            "history": [
+                *first_payload["history"],
+                {
+                    "id": "m-assistant-2",
+                    "role": "assistant",
+                    "created_at": "2026-04-08T10:01:00",
+                    "content": [{"type": "text", "text": "hi"}],
+                },
+            ],
+        }
+
+        store._append_jsonl_snapshot(
+            jsonl_path,
+            checkpoint_path=checkpoint_path,
+            payload=first_payload,
+            agent=agent,
+        )
+        store._append_jsonl_snapshot(
+            jsonl_path,
+            checkpoint_path=checkpoint_path,
+            payload=second_payload,
+            agent=agent,
+        )
+
+        events = [json.loads(line) for line in jsonl_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        user_events = [event for event in events if event.get("type") == "user_message"]
+        agent_events = [event for event in events if event.get("type") == "agent_message"]
+        checkpoint_refs = [event for event in events if event.get("type") == "checkpoint_ref"]
+
+        assert len(user_events) == 1
+        assert len(agent_events) == 1
+        assert len(checkpoint_refs) == 2
+
+        checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        assert checkpoint["type"] == "session_checkpoint"
+        assert len(checkpoint["payload"]["history"]) == 2


### PR DESCRIPTION
## Background
  This PR addresses three key gaps in current NexAU CLI:
  1. No practical session management UX in CLI.
  2. No runtime model switching through CLI.
  3. Main agent and sub-agent had shared-state conflicts (`skill_registry`), causing sub-agent behavior to overwrite main-agent
  state.

  ## What’s Added
  - Session management in CLI (`/resume`):
    - Interactive session picker (list/search/select).
    - Resume existing session or start a fresh one from the same flow.
  - Runtime model switching in CLI (`/model`):
    - Interactive model picker and direct switching in current session.
    - Supports multiple configured models/profiles.
  - Session persistence upgrade:
    - Per-session storage with `messages.jsonl` + `session_checkpoint.json`.
    - Incremental event persistence for user/agent/tool records.
  - State isolation fix for main/sub agents:
    - Avoid persisting transient shared keys like `skill_registry`, preventing sub-agent overwrite of main-agent skill state.

  ## Result
  NexAU now supports usable session lifecycle management, model switching in CLI, and stable main/sub-agent state separation.