### PR TITLE
fix(sandbox/e2b): keepalive 改调 /refreshes endpoint(修 set_timeout 覆盖 bug)

### DIFF
--- a/nexau/archs/sandbox/e2b_sandbox.py
+++ b/nexau/archs/sandbox/e2b_sandbox.py
@@ -98,6 +98,59 @@ except (ImportError, ModuleNotFoundError, AttributeError):
 E2B_AVAILABLE = _e2b_available
 
 
+def _post_sandbox_refreshes(
+    sandbox_id: str,
+    duration: int,
+    api_url: str | None = None,
+    api_key: str | None = None,
+) -> None:
+    """Call POST /sandboxes/{sandbox_id}/refreshes (E2B-compat 心跳续期 endpoint).
+
+    跟 set_timeout 区别:
+    - set_timeout 是用户显式 set,任何值都生效(允许缩短)
+    - refreshes 是 SDK 心跳,**不允许缩短** (extend-only) — 后端用 GREATEST(current, $duration)
+
+    路径 /sandboxes/{id}/refreshes 在 NAC backend 和 E2B SaaS 都实现,
+    所以这个调用对两个 backend 都正确。
+
+    Args:
+        sandbox_id: Sandbox ID
+        duration: 期望的 timeout 秒数(后端会 max(current, duration))
+        api_url: Backend API URL,缺省走 E2B_API_URL env
+        api_key: API key,缺省走 E2B_API_KEY env
+
+    Raises:
+        SandboxNotFoundException: 404
+        E2B SDK exceptions: 其他错误(409 sandbox not running 等)
+    """
+    if Sandbox is None:
+        raise RuntimeError("E2B SDK not installed; cannot call /sandboxes/.../refreshes")
+
+    # Lazy import — 跟 E2B SDK 内部 set_timeout 同模式
+    from e2b.api import handle_api_exception
+    from e2b.api.client.api.sandboxes import post_sandboxes_sandbox_id_refreshes
+    from e2b.api.client.models import PostSandboxesSandboxIDRefreshesBody
+    from e2b.api.client_sync import get_api_client
+    from e2b.connection_config import ConnectionConfig
+    from e2b.exceptions import NotFoundException
+
+    config = ConnectionConfig(api_url=api_url, api_key=api_key)
+    if config.debug:
+        return
+
+    api_client = get_api_client(config)
+    res = post_sandboxes_sandbox_id_refreshes.sync_detailed(
+        sandbox_id,
+        client=api_client,
+        body=PostSandboxesSandboxIDRefreshesBody(duration=duration),
+    )
+
+    if res.status_code == 404:
+        raise NotFoundException(f"Sandbox {sandbox_id} not found")
+    if res.status_code >= 300:
+        raise handle_api_exception(res)
+
+
 @dataclass(kw_only=True)
 class E2BSandbox(BaseSandbox):
     """
@@ -2035,9 +2088,23 @@ class E2BSandboxManager(BaseSandboxManager[E2BSandbox]):
     # -------------------------------------------------------------------------
 
     def _start_keepalive(self, sandbox_id: str | None, interval: int) -> None:
-        """Start a daemon thread that periodically calls set_timeout.
+        """Start a daemon thread that periodically refreshes the sandbox idle timer.
 
         Prevents the idle checker from pausing the sandbox during long agent runs.
+
+        ## 为什么用 refresh 而不是 set_timeout(2026-05 修)
+
+        `set_timeout` 是 "用户显式 set,任何值都生效"(allowShorter=true);
+        `refresh` 是 "心跳续期,不能缩短现有 timeout"(allowShorter=false)。
+
+        之前 keepalive 调 set_timeout(mgr_timeout) 每 60s 一次,如果用户
+        显式 sandbox.set_timeout(7200) 想扩到 2h → 60s 后被这条心跳 silently
+        覆盖回 mgr_timeout(默认 300)→ 5 分钟后被 idle pause。
+
+        改用 /refreshes endpoint(extend-only 语义)修这个 bug。
+
+        路径 `/sandboxes/{id}/refreshes` 是 NAC 跟 E2B SaaS 双方都实现的,
+        所以这个 SDK 行为对两个 backend 都正确。
         """
         if interval <= 0 or not sandbox_id or Sandbox is None:
             return
@@ -2051,13 +2118,13 @@ class E2BSandboxManager(BaseSandboxManager[E2BSandbox]):
         def _loop() -> None:
             while not self._keepalive_stop_event.wait(interval):
                 try:
-                    sandbox_cls.set_timeout(
-                        sandbox_id,
-                        mgr_timeout,
+                    _post_sandbox_refreshes(
+                        sandbox_id=sandbox_id,
+                        duration=mgr_timeout,
                         api_url=mgr_api_url,
                         api_key=mgr_api_key,
                     )
-                    logger.debug(f"Keepalive sent: {sandbox_id[:8]}...")
+                    logger.debug(f"Keepalive (refresh) sent: {sandbox_id[:8]}...")
                 except Exception as exc:
                     err_msg = str(exc).lower()
                     if "409" in err_msg or "not running" in err_msg:

--- a/tests/unit/archs/sandbox/test_e2b_sandbox_unit.py
+++ b/tests/unit/archs/sandbox/test_e2b_sandbox_unit.py
@@ -1000,29 +1000,35 @@ class TestManagerDefensive:
         assert manager._keepalive_thread is None
 
     def test_keepalive_starts_and_stops(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # 注:keepalive 现在调 _post_sandbox_refreshes(/refreshes endpoint),
+        # 而不是 Sandbox.set_timeout —— 修了 set_timeout silently 覆盖用户值的 bug
         backend = _FakeSandbox()
-        cls = _enable_fake_e2b(monkeypatch, backend)
-        set_timeout_calls = []
-        cls.set_timeout = lambda sid, t, **kw: set_timeout_calls.append(sid)  # type: ignore
+        _enable_fake_e2b(monkeypatch, backend)
+        refresh_calls: list[str] = []
+
+        def fake_refresh(sandbox_id: str, duration: int, **kw: object) -> None:
+            refresh_calls.append(sandbox_id)
+
+        monkeypatch.setattr(e2b_module, "_post_sandbox_refreshes", fake_refresh)
         manager = e2b_module.E2BSandboxManager(api_key="key")
         manager._start_keepalive("sbx-ka", 1)
         assert manager._keepalive_thread is not None
         time.sleep(1.5)
         manager._stop_keepalive()
         assert manager._keepalive_thread is None
-        assert len(set_timeout_calls) >= 1
+        assert len(refresh_calls) >= 1, "keepalive 应至少调一次 _post_sandbox_refreshes"
 
     def test_keepalive_handles_409_auto_resume(self, monkeypatch: pytest.MonkeyPatch) -> None:
         backend = _FakeSandbox()
         cls = _enable_fake_e2b(monkeypatch, backend)
         call_count = [0]
 
-        def failing_set_timeout(sid: str, t: int, **kw: object) -> None:
+        def failing_refresh(sandbox_id: str, duration: int, **kw: object) -> None:
             call_count[0] += 1
             if call_count[0] == 1:
                 raise RuntimeError("409 sandbox not running")
 
-        cls.set_timeout = failing_set_timeout  # type: ignore
+        monkeypatch.setattr(e2b_module, "_post_sandbox_refreshes", failing_refresh)
         connect_calls: list[str] = []
 
         def tracking_connect(sandbox_id: str, **kw: object) -> _FakeSandbox:
@@ -1034,22 +1040,30 @@ class TestManagerDefensive:
         manager._start_keepalive("sbx-409", 1)
         time.sleep(1.5)
         manager._stop_keepalive()
-        assert len(connect_calls) >= 1
+        assert len(connect_calls) >= 1, "409 应触发 auto-resume(connect)"
 
     def test_keepalive_handles_generic_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         backend = _FakeSandbox()
-        cls = _enable_fake_e2b(monkeypatch, backend)
-        cls.set_timeout = lambda sid, t, **kw: (_ for _ in ()).throw(RuntimeError("network error"))  # type: ignore
+        _enable_fake_e2b(monkeypatch, backend)
+
+        def err_refresh(sandbox_id: str, duration: int, **kw: object) -> None:
+            raise RuntimeError("network error")
+
+        monkeypatch.setattr(e2b_module, "_post_sandbox_refreshes", err_refresh)
         manager = e2b_module.E2BSandboxManager(api_key="key")
         manager._start_keepalive("sbx-err", 1)
         time.sleep(1.5)
         manager._stop_keepalive()
-        # Should not crash
+        # 不该崩
 
     def test_keepalive_auto_resume_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         backend = _FakeSandbox()
         cls = _enable_fake_e2b(monkeypatch, backend)
-        cls.set_timeout = lambda sid, t, **kw: (_ for _ in ()).throw(RuntimeError("409 not running"))  # type: ignore
+
+        def err_refresh(sandbox_id: str, duration: int, **kw: object) -> None:
+            raise RuntimeError("409 not running")
+
+        monkeypatch.setattr(e2b_module, "_post_sandbox_refreshes", err_refresh)
 
         def failing_connect(sandbox_id: str, **kw: object) -> _FakeSandbox:
             raise RuntimeError("resume failed")
@@ -1098,3 +1112,68 @@ class TestBuildSandboxResetsSingleton:
         assert _FakeTWL.singleton is not None
         manager._build_sandbox_with_connection_config("sbx", "example.com", "token", Version("0.1.4"))
         assert _FakeTWL.singleton is None
+
+
+class TestPostSandboxRefreshes:
+    """Unit tests for the _post_sandbox_refreshes helper(/sandboxes/{id}/refreshes)."""
+
+    def test_helper_calls_refreshes_endpoint_with_duration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # post_sandboxes_sandbox_id_refreshes 是个**子模块**(不是模块级函数),
+        # 所以 patch 它的 sync_detailed 函数,而不是 parent module 的属性
+        import e2b.api.client_sync as _client_sync
+        import e2b.connection_config as _conn
+        from e2b.api.client.api.sandboxes import post_sandboxes_sandbox_id_refreshes as _refreshes_mod
+
+        captured: dict[str, object] = {}
+
+        def fake_sync_detailed(sandbox_id: str, *, client: object, body: object) -> object:
+            captured["sandbox_id"] = sandbox_id
+            captured["body"] = body
+            return type("Res", (), {"status_code": 204})()
+
+        monkeypatch.setattr(_refreshes_mod, "sync_detailed", fake_sync_detailed)
+        monkeypatch.setattr(_client_sync, "get_api_client", lambda config: object())
+        monkeypatch.setattr(_conn, "ConnectionConfig", lambda **kw: type("C", (), {"debug": False})())
+
+        e2b_module._post_sandbox_refreshes(
+            sandbox_id="sbx-test",
+            duration=14400,
+            api_url="http://nac",
+            api_key="key",
+        )
+
+        assert captured["sandbox_id"] == "sbx-test"
+        assert captured["body"].duration == 14400  # type: ignore[attr-defined]
+
+    def test_helper_skips_in_debug_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # config.debug=True → 直接 return,不发请求(对齐 E2B SDK set_timeout 同模式)
+        import e2b.connection_config as _conn
+        from e2b.api.client.api.sandboxes import post_sandboxes_sandbox_id_refreshes as _refreshes_mod
+
+        called = [False]
+
+        def fake_sync_detailed(sandbox_id: str, *, client: object, body: object) -> object:
+            called[0] = True
+            return object()
+
+        monkeypatch.setattr(_refreshes_mod, "sync_detailed", fake_sync_detailed)
+        monkeypatch.setattr(_conn, "ConnectionConfig", lambda **kw: type("C", (), {"debug": True})())
+
+        e2b_module._post_sandbox_refreshes(sandbox_id="sbx", duration=300)
+        assert not called[0], "debug 模式应跳过 refresh 调用"
+
+    def test_helper_raises_404_as_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import e2b.api.client_sync as _client_sync
+        import e2b.connection_config as _conn
+        from e2b.api.client.api.sandboxes import post_sandboxes_sandbox_id_refreshes as _refreshes_mod
+        from e2b.exceptions import NotFoundException
+
+        def fake_sync_detailed(sandbox_id: str, *, client: object, body: object) -> object:
+            return type("Res", (), {"status_code": 404})()
+
+        monkeypatch.setattr(_refreshes_mod, "sync_detailed", fake_sync_detailed)
+        monkeypatch.setattr(_client_sync, "get_api_client", lambda config: object())
+        monkeypatch.setattr(_conn, "ConnectionConfig", lambda **kw: type("C", (), {"debug": False})())
+
+        with pytest.raises(NotFoundException, match="not found"):
+            e2b_module._post_sandbox_refreshes(sandbox_id="missing", duration=300)


### PR DESCRIPTION
## 变更摘要

修 keepalive silently override 用户 `set_timeout(N)` 的 bug：之前每 60s 调一次 `Sandbox.set_timeout(mgr_timeout)`，会把用户显式设置的更长 timeout 覆盖回 mgr_timeout（默认 300）→ 5min 后被 idle pause。

**修复**：keepalive 改调 E2B-compat 的 `/sandboxes/{id}/refreshes` endpoint（`allowShorter=false` 语义，extend-only，不缩短现有 timeout）。

## 配套依赖

需要 NAC backend 已合 [nexau-cloud-runtime#548](https://github.com/china-qijizhifeng/nexau-cloud-runtime/pull/548) — 该 PR 给 NAC 后端加了 `/sandboxes/{id}/refreshes` endpoint（路径名跟 E2B SaaS 完全对齐）。E2B SaaS 早就有这条 endpoint，所以新 SDK 行为对两个 backend 都正确。

## 改动

- **新增**模块级 helper `_post_sandbox_refreshes(sandbox_id, duration, api_url, api_key)`：
  - 复用 E2B SDK 内部 API client（`post_sandboxes_sandbox_id_refreshes`）
  - 构造跟 SDK 原生 `set_timeout` 同模式（`ConnectionConfig` + `get_api_client`）
  - 处理 404 → `NotFoundException`，>=300 → `handle_api_exception`
- `_start_keepalive` 改调 `_post_sandbox_refreshes`，不再走 `sandbox_cls.set_timeout`
- 4 个原 keepalive 测试更新 monkeypatch 目标
- 3 个新 helper 单测：duration 传递 / debug skip / 404 raise

## 兼容性 / 升级路线

| 场景 | 行为 |
|------|------|
| 用户显式 `sandbox.set_timeout(N)` | 不变（走 SDK 原生 `set_timeout`，hits `/timeout`，任意值生效） |
| 用户传 `keepalive_interval=0` 关 keepalive | 不变 |
| keepalive 自动续期 | 改走 `/refreshes`，extend-only |
| **旧 NAC backend（没 #548 endpoint）+ 新 SDK** | keepalive 心跳会 404，需要先升级 NAC backend |
| E2B SaaS（一直有 `/refreshes`） | ✅ |

部署顺序：**NAC backend #548 必须先合并部署**，再升级 SDK + agent-runtime。

## 测试

```bash
uv run pytest tests/unit/archs/sandbox/test_e2b_sandbox_unit.py \
    -k "keepalive or PostSandboxRefreshes"
# → 9 passed (6 keepalive + 3 helper)

uv run ruff format/check → clean
```

## 关联

- nexau-cloud-runtime#548（后端 endpoint，必须先合）
- nexau-cloud-runtime#547（bug tracking issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
