### PR TITLE
fix(prompt-cache): use date-only runtime date and clamp cache_control breakpoints

### DIFF
--- a/nexau/archs/main_sub/execution/llm_caller.py
+++ b/nexau/archs/main_sub/execution/llm_caller.py
@@ -1532,6 +1532,44 @@ def _strip_responses_api_artifacts(messages: list[Any]) -> list[Any]:
     return sanitized
 
 
+# Anthropic rejects requests carrying more than four ``cache_control``
+# breakpoints with a 400 error. We allocate them prefix-first (system blocks
+# before the trailing user block) so the largest stable prefix stays cached.
+_MAX_CACHE_CONTROL_BREAKPOINTS = 4
+
+
+def _apply_anthropic_cache_control(
+    system_messages: list[dict[str, Any]],
+    user_messages: list[dict[str, Any]],
+    build_cache_control: Callable[[], dict[str, str]],
+) -> None:
+    """Apply Anthropic ``cache_control`` to system and user message blocks.
+
+    System blocks carry a ``_cache`` flag from ``SystemPromptBlock``
+    configuration; when absent the default is to cache. The total number of
+    breakpoints is clamped to :data:`_MAX_CACHE_CONTROL_BREAKPOINTS` because
+    Anthropic returns a 400 error when a request exceeds four. Breakpoints are
+    assigned prefix-first so the longest stable prefix remains cacheable.
+    """
+    remaining = _MAX_CACHE_CONTROL_BREAKPOINTS
+
+    for sys_block in system_messages:
+        should_cache = sys_block.pop("_cache", True)
+        if should_cache and remaining > 0:
+            sys_block["cache_control"] = build_cache_control()
+            remaining -= 1
+
+    if remaining > 0 and user_messages and user_messages[-1].get("content"):
+        content = cast(list[dict[str, Any]] | str | None, user_messages[-1].get("content"))
+        if isinstance(content, list) and content:
+            # RFC-0014: thinking/redacted_thinking blocks 不允许携带 cache_control
+            no_cache_types = {"thinking", "redacted_thinking"}
+            for block in content:
+                if block.get("type") not in no_cache_types:
+                    block["cache_control"] = build_cache_control()
+                    break
+
+
 def call_llm_with_anthropic_chat_completion(
     client: Any,
     kwargs: dict[str, Any],
@@ -1558,25 +1596,7 @@ def call_llm_with_anthropic_chat_completion(
         system_messages: list[dict[str, Any]],
         user_messages: list[dict[str, Any]],
     ) -> None:
-        """Apply Anthropic cache_control to system and user message blocks.
-
-        System blocks carry a ``_cache`` flag from SystemPromptBlock
-        configuration; when absent the default is to cache.
-        """
-        for sys_block in system_messages:
-            should_cache = sys_block.pop("_cache", True)
-            if should_cache:
-                sys_block["cache_control"] = _build_cache_control()
-
-        if user_messages and user_messages[-1].get("content"):
-            content = cast(list[dict[str, Any]] | str | None, user_messages[-1].get("content"))
-            if isinstance(content, list) and content:
-                # RFC-0014: thinking/redacted_thinking blocks 不允许携带 cache_control
-                no_cache_types = {"thinking", "redacted_thinking"}
-                for block in content:
-                    if block.get("type") not in no_cache_types:
-                        block["cache_control"] = _build_cache_control()
-                        break
+        _apply_anthropic_cache_control(system_messages, user_messages, _build_cache_control)
 
     def _build_anthropic_messages() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         if type(model_call_params) is not ModelCallParams:
@@ -2151,19 +2171,7 @@ async def call_llm_with_anthropic_chat_completion_async(
         system_messages: list[dict[str, Any]],
         user_messages: list[dict[str, Any]],
     ) -> None:
-        for sys_block in system_messages:
-            should_cache = sys_block.pop("_cache", True)
-            if should_cache:
-                sys_block["cache_control"] = _build_cache_control()
-        if user_messages and user_messages[-1].get("content"):
-            content = cast(list[dict[str, Any]] | str | None, user_messages[-1].get("content"))
-            if isinstance(content, list) and content:
-                # RFC-0014: thinking/redacted_thinking blocks 不允许携带 cache_control
-                no_cache_types = {"thinking", "redacted_thinking"}
-                for block in content:
-                    if block.get("type") not in no_cache_types:
-                        block["cache_control"] = _build_cache_control()
-                        break
+        _apply_anthropic_cache_control(system_messages, user_messages, _build_cache_control)
 
     def _build_anthropic_messages() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         if type(model_call_params) is not ModelCallParams:

--- a/nexau/archs/main_sub/runtime_context.py
+++ b/nexau/archs/main_sub/runtime_context.py
@@ -25,8 +25,15 @@ from typing import Any
 
 
 def get_runtime_date() -> str:
-    """Return the current local date-time string used in prompts."""
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    """Return the current local date string used in prompts.
+
+    The value lands in the cached system-prompt prefix (the ``{{date}}``
+    template variable used by shipped agents). Caching is a prefix match, so a
+    second-precision timestamp here changes the prefix on every request and
+    drives the cache hit rate to zero. Returning a date-only string keeps the
+    cached prefix stable for the lifetime of a calendar day.
+    """
+    return datetime.now().strftime("%Y-%m-%d")
 
 
 def current_username() -> str:

--- a/tests/unit/test_llm_caller.py
+++ b/tests/unit/test_llm_caller.py
@@ -2126,3 +2126,98 @@ class TestAnthropicCacheControl:
         assistant_blocks = sent_messages[1]["content"]
         assert assistant_blocks[0] == {"type": "thinking", "thinking": "openai responses reasoning"}
         assert "signature" not in assistant_blocks[0]
+
+
+class TestAnthropicCacheControlBreakpointClamp:
+    """Tests for clamping total cache_control breakpoints to Anthropic's limit of 4."""
+
+    @staticmethod
+    def _ephemeral() -> dict[str, str]:
+        return {"type": "ephemeral"}
+
+    def test_breakpoints_clamped_to_four_with_many_cacheable_blocks(self):
+        """Six cacheable system blocks + a user block must not exceed four breakpoints."""
+        from nexau.archs.main_sub.execution.llm_caller import _apply_anthropic_cache_control
+
+        system_messages: list[dict[str, object]] = [
+            {"type": "text", "text": f"block {i}", "_cache": True} for i in range(6)
+        ]
+        user_messages: list[dict[str, object]] = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+        ]
+
+        _apply_anthropic_cache_control(system_messages, user_messages, self._ephemeral)
+
+        cached_system = [b for b in system_messages if "cache_control" in b]
+        user_content = user_messages[-1]["content"]
+        assert isinstance(user_content, list)
+        cached_user = [b for b in user_content if "cache_control" in b]
+
+        total = len(cached_system) + len(cached_user)
+        assert total == 4, total
+        # Prefix-first allocation: all four land on the leading system blocks,
+        # leaving none for the user block.
+        assert len(cached_system) == 4
+        assert len(cached_user) == 0
+        # The _cache scaffolding flag is always consumed.
+        assert all("_cache" not in b for b in system_messages)
+
+    def test_user_block_cached_when_system_blocks_leave_headroom(self):
+        """With few system blocks, the trailing user block still gets a breakpoint."""
+        from nexau.archs.main_sub.execution.llm_caller import _apply_anthropic_cache_control
+
+        system_messages: list[dict[str, object]] = [
+            {"type": "text", "text": "static", "_cache": True},
+            {"type": "text", "text": "dynamic", "_cache": False},
+        ]
+        user_messages: list[dict[str, object]] = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+        ]
+
+        _apply_anthropic_cache_control(system_messages, user_messages, self._ephemeral)
+
+        assert system_messages[0].get("cache_control") == {"type": "ephemeral"}
+        assert "cache_control" not in system_messages[1]
+        user_content = user_messages[-1]["content"]
+        assert isinstance(user_content, list)
+        assert user_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_exactly_four_cacheable_system_blocks_leaves_user_uncached(self):
+        """Four cacheable system blocks exhaust the budget before the user block."""
+        from nexau.archs.main_sub.execution.llm_caller import _apply_anthropic_cache_control
+
+        system_messages: list[dict[str, object]] = [
+            {"type": "text", "text": f"block {i}", "_cache": True} for i in range(4)
+        ]
+        user_messages: list[dict[str, object]] = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+        ]
+
+        _apply_anthropic_cache_control(system_messages, user_messages, self._ephemeral)
+
+        assert all(b.get("cache_control") == {"type": "ephemeral"} for b in system_messages)
+        user_content = user_messages[-1]["content"]
+        assert isinstance(user_content, list)
+        assert "cache_control" not in user_content[0]
+
+    def test_thinking_blocks_are_skipped_for_user_breakpoint(self):
+        """A leading thinking block is skipped so cache_control lands on a real block."""
+        from nexau.archs.main_sub.execution.llm_caller import _apply_anthropic_cache_control
+
+        system_messages: list[dict[str, object]] = []
+        user_messages: list[dict[str, object]] = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "thinking", "thinking": "..."},
+                    {"type": "text", "text": "hello"},
+                ],
+            }
+        ]
+
+        _apply_anthropic_cache_control(system_messages, user_messages, self._ephemeral)
+
+        user_content = user_messages[-1]["content"]
+        assert isinstance(user_content, list)
+        assert "cache_control" not in user_content[0]
+        assert user_content[1].get("cache_control") == {"type": "ephemeral"}

--- a/tests/unit/test_prompt_builder.py
+++ b/tests/unit/test_prompt_builder.py
@@ -204,6 +204,48 @@ class TestBuildSystemPrompt:
         mock_base.assert_called_once()
         mock_caps.assert_called_once()
 
+    def test_runtime_date_is_date_only_for_cache_stability(self):
+        """The runtime ``date`` must not carry a time-of-day component.
+
+        It lands in the cached system-prompt prefix (the ``{{date}}`` template
+        variable used by shipped agents). A second-precision timestamp there
+        changes the prefix on every request and collapses the cache hit rate,
+        so the value must be date-only and stable within a calendar day.
+        """
+        import re
+
+        from nexau.archs.main_sub.runtime_context import build_runtime_prompt_context, get_runtime_date
+
+        date_value = get_runtime_date()
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", date_value), date_value
+        # No time-of-day component (HH:MM:SS) anywhere in the value.
+        assert not re.search(r"\d{2}:\d{2}", date_value), date_value
+
+        context = build_runtime_prompt_context()
+        assert context["date"] == date_value
+        assert not re.search(r"\d{2}:\d{2}", str(context["date"]))
+
+    def test_runtime_date_renders_without_time_in_cached_prompt(self, mock_config):
+        """The rendered system prompt prefix carries no time-of-day from ``{{date}}``."""
+        import re
+
+        from nexau.archs.main_sub.prompt_builder import SystemPromptPart
+        from nexau.archs.main_sub.runtime_context import build_runtime_prompt_context
+
+        builder = PromptBuilder()
+        runtime_context = build_runtime_prompt_context()
+        rendered = f"Date: {runtime_context['date']}.\n"
+
+        with patch.object(builder, "_get_base_system_prompt", return_value=[SystemPromptPart(text=rendered)]):
+            with patch.object(builder, "_build_capabilities_docs", return_value="Caps\n"):
+                with patch.object(builder, "_get_tool_execution_instructions", return_value="Inst\n"):
+                    result = builder.build_system_prompt(
+                        mock_config,
+                        runtime_context=runtime_context,
+                    )
+
+        assert not re.search(r"\d{2}:\d{2}:\d{2}", result[0].text), result[0].text
+
     def test_build_system_prompt_does_not_force_runtime_platform_contract(self, mock_config):
         """Runtime environment facts stay available as template variables only."""
         from nexau.archs.main_sub.prompt_builder import SystemPromptPart


### PR DESCRIPTION
## Summary

Two prompt-caching fixes in the Anthropic call path. The first is a live cache-defeating bug; the second is defensive hardening against a latent 400.

### 1. Second-precision date in the cached system prefix (primary)

`get_runtime_date()` in `nexau/archs/main_sub/runtime_context.py` returned a second-precision string:

```python
return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
```

That value is exposed as the `{{date}}` template variable and rendered into the **cached** system prompt prefix. The shipped example agents use it directly — e.g. `examples/deep_research/deep_research_agent.yaml`:

```yaml
system_prompt: "Date: {{date}}. You are a deep research agent. ..."
```

Anthropic prompt caching is a prefix match: any byte change in the prefix invalidates the cache for everything after it. Because the rendered date changes every second, the system prefix is different on every request, so `cache_read_input_tokens` stays at zero and the cache never pays off — the whole system prompt (and tools, which render before it) is re-billed at full input price on every call.

**Fix:** return a date-only string (`%Y-%m-%d`). The cached prefix is now stable for the lifetime of a calendar day, so repeated requests hit the cache. Return type stays `str`.

### 2. Unclamped `cache_control` breakpoints (defensive)

`_apply_cache_control` in `nexau/archs/main_sub/execution/llm_caller.py` (sync ~l.1557 and async ~l.2150) added a `cache_control` breakpoint to **every** cacheable system block plus one trailing user block, with no upper bound. Anthropic rejects any request carrying more than 4 `cache_control` breakpoints with a 400. With 4 or more cacheable system blocks the request exceeds the limit and fails.

**Fix:** extract the shared logic into a single module-level helper, `_apply_anthropic_cache_control`, and clamp the total to 4 (`_MAX_CACHE_CONTROL_BREAKPOINTS`). Breakpoints are allocated prefix-first (system blocks before the trailing user block) so the longest stable prefix stays cacheable. This also de-duplicates the previously copy-pasted sync/async closures. This is latent hardening — most configs stay under 4 — but it removes a sharp edge for agents with several cacheable system blocks.

## Tests

- `tests/unit/test_prompt_builder.py`: assert the runtime `date` is date-only and that the rendered system prefix carries no time-of-day component.
- `tests/unit/test_llm_caller.py`: new `TestAnthropicCacheControlBreakpointClamp` covering the ≤4 clamp with many cacheable blocks, prefix-first allocation, the user-block-gets-a-breakpoint case when there's headroom, the exactly-4 boundary, and thinking-block skipping.

## Validation

- `make typecheck` (mypy + pyright): clean — mypy "no issues found in 489 source files", pyright "0 errors, 0 warnings".
- `uv run pytest tests/unit/test_prompt_builder.py tests/unit/test_llm_caller.py -v`: passes (86 passed, 40 pre-existing skips).

Fully typed signatures, no `Any`-typed locals introduced, no `# type: ignore`.
