### PR TITLE
fix:Fix broken Quick Start code agent example paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ uv sync
     from nexau.archs.main_sub.execution.hooks import LoggingMiddleware
     from nexau.archs.tracer.adapters.langfuse import LangfuseTracer
     from nexau.archs.tool.builtin import (
-        glob,
         google_web_search,
         list_directory,
         read_file,
@@ -119,7 +118,6 @@ uv sync
         Tool.from_yaml(base_dir / "tools/WebFetch.tool.yaml", binding=web_fetch),
         Tool.from_yaml(base_dir / "tools/write_todos.tool.yaml", binding=write_todos),
         Tool.from_yaml(base_dir / "tools/search_file_content.tool.yaml", binding=search_file_content),
-        Tool.from_yaml(base_dir / "tools/Glob.tool.yaml", binding=glob),
         Tool.from_yaml(base_dir / "tools/read_file.tool.yaml", binding=read_file),
         Tool.from_yaml(base_dir / "tools/write_file.tool.yaml", binding=write_file),
         Tool.from_yaml(base_dir / "tools/replace.tool.yaml", binding=replace),
@@ -130,8 +128,8 @@ uv sync
 
     # NexAU supports Skills (compatible with Claude Skills)
     skills = [
-        Skill.from_folder(base_dir / "skills/theme-factory"),
-        Skill.from_folder(base_dir / "skills/algorithmic-art"),
+        Skill.from_folder(base_dir / "skills/skill-creator"),
+        Skill.from_folder(base_dir / "skills/template-skill"),
     ]
 
     # Tracer allows you to forward execution data for observability.
@@ -144,7 +142,7 @@ uv sync
     agent_config = AgentConfig(
         name="nexau_code_agent",
         max_context_tokens=100000,
-        system_prompt=str(base_dir / "system-workflow.md"),
+        system_prompt=str(base_dir / "systemprompt.md"),
         system_prompt_type="jinja",
         tool_call_mode="structured", # xml or structured
         llm_config=LLMConfig(

--- a/README_CN.md
+++ b/README_CN.md
@@ -96,7 +96,6 @@ uv sync
     from nexau.archs.main_sub.execution.hooks import LoggingMiddleware
 
     from nexau.archs.tool.builtin import (
-        glob,
         google_web_search,
         list_directory,
         read_file,
@@ -119,7 +118,6 @@ uv sync
         Tool.from_yaml(base_dir / "tools/WebFetch.tool.yaml", binding=web_fetch),
         Tool.from_yaml(base_dir / "tools/write_todos.tool.yaml", binding=write_todos),
         Tool.from_yaml(base_dir / "tools/search_file_content.tool.yaml", binding=search_file_content),
-        Tool.from_yaml(base_dir / "tools/Glob.tool.yaml", binding=glob),
         Tool.from_yaml(base_dir / "tools/read_file.tool.yaml", binding=read_file),
         Tool.from_yaml(base_dir / "tools/write_file.tool.yaml", binding=write_file),
         Tool.from_yaml(base_dir / "tools/replace.tool.yaml", binding=replace),
@@ -130,8 +128,8 @@ uv sync
 
     # NexAU supports Skills (compatible with Claude Skills)
     skills = [
-        Skill.from_folder(base_dir / "skills/theme-factory"),
-        Skill.from_folder(base_dir / "skills/algorithmic-art"),
+        Skill.from_folder(base_dir / "skills/skill-creator"),
+        Skill.from_folder(base_dir / "skills/template-skill"),
     ]
 
     # Tracer allows you to forward execution data for observability.
@@ -144,7 +142,7 @@ uv sync
     agent_config = AgentConfig(
         name="nexau_code_agent",
         max_context_tokens=100000,
-        system_prompt=str(base_dir / "system-workflow.md"),
+        system_prompt=str(base_dir / "systemprompt.md"),
         system_prompt_type="jinja",
         tool_call_mode="structured", # xml 或 structured
         llm_config=LLMConfig(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,6 @@ tree:
     from nexau.archs.main_sub.execution.hooks import LoggingMiddleware
 
     from nexau.archs.tool.builtin import (
-        glob,
         google_web_search,
         list_directory,
         read_file,
@@ -117,7 +116,6 @@ tree:
         Tool.from_yaml(base_dir / "tools/WebFetch.tool.yaml", binding=web_fetch),
         Tool.from_yaml(base_dir / "tools/write_todos.tool.yaml", binding=write_todos),
         Tool.from_yaml(base_dir / "tools/search_file_content.tool.yaml", binding=search_file_content),
-        Tool.from_yaml(base_dir / "tools/Glob.tool.yaml", binding=glob),
         Tool.from_yaml(base_dir / "tools/read_file.tool.yaml", binding=read_file),
         Tool.from_yaml(base_dir / "tools/write_file.tool.yaml", binding=write_file),
         Tool.from_yaml(base_dir / "tools/replace.tool.yaml", binding=replace),
@@ -128,14 +126,14 @@ tree:
 
     # NexAU supports Skills (compatible with Claude Skills)
     skills = [
-        Skill.from_folder(base_dir / "skills/theme-factory"),
-        Skill.from_folder(base_dir / "skills/algorithmic-art"),
+        Skill.from_folder(base_dir / "skills/skill-creator"),
+        Skill.from_folder(base_dir / "skills/template-skill"),
     ]
 
     agent_config = AgentConfig(
         name="nexau_code_agent",
         max_context_tokens=100000,
-        system_prompt=str(base_dir / "system-workflow.md"),
+        system_prompt=str(base_dir / "systemprompt.md"),
         system_prompt_type="jinja",
         tool_call_mode="structured", # xml or structured
         llm_config=LLMConfig(


### PR DESCRIPTION
## Summary

Fixes broken paths in the Quick Start Python code agent examples.

The examples previously referenced files and skill folders that do not exist in `examples/code_agent`, which would cause users copying the snippet to fail immediately.

## Changes

- Removed the nonexistent `tools/Glob.tool.yaml` reference
- Updated skill paths to existing folders:
  - `skills/skill-creator`
  - `skills/template-skill`
- Updated the system prompt path from `system-workflow.md` to `systemprompt.md`
- Applied the same fix to `README.md`, `README_CN.md`, and `docs/getting-started.md`

## Verification

- Confirmed all referenced example paths now exist
- Ran Python 3.12 compile check successfully