### PR TITLE
修复子代理 deadline 与 per-run budget 门禁

### DIFF
--- a/docs/core-concepts/agents.md
+++ b/docs/core-concepts/agents.md
@@ -71,8 +71,19 @@ For a more declarative approach, you can define an agent's entire configuration 
       - name: web_read
           yaml_path: ./tools/WebRead.yaml
         binding: nexau.archs.tool.builtin.web_tools:web_fetch
-    sub_agents: []
+    sub_agents:
+      - name: researcher
+        config_path: ./agents/researcher.yaml
+        # Optional invocation controls; omitted means unlimited/backward compatible.
+        timeout_seconds: 60.0
+        max_calls_per_run: 2
     ```
+
+    `timeout_seconds` is measured from the Agent tool invocation and returns a
+    structured terminal `partial` result with reason `AGENT_DEADLINE_EXCEEDED`.
+    `max_calls_per_run` is counted independently for each parent execution; a
+    later run starts with a fresh budget. Exhaustion returns
+    `DELEGATION_BUDGET_EXHAUSTED` without starting another child.
 
 2.  **Load and use the agent in Python:**
 

--- a/nexau/archs/main_sub/config/base.py
+++ b/nexau/archs/main_sub/config/base.py
@@ -95,5 +95,7 @@ class AgentConfigBase[TTool, TSkill, TSubAgent, THook](BaseModel):
     retry_attempts: int = Field(default=5, ge=0)
     retry_backoff_max_seconds: int = Field(default=30, ge=1)
     timeout: int = Field(default=300, ge=1)
+    timeout_seconds: float | None = Field(default=None, gt=0)
+    max_calls_per_run: int | None = Field(default=None, gt=0)
     tracers: list[Any] = Field(default_factory=list)
     skipped_components: list[str] = Field(default_factory=list)

--- a/nexau/archs/main_sub/config/config.py
+++ b/nexau/archs/main_sub/config/config.py
@@ -365,7 +365,7 @@ class AgentConfig(
         """
         if self._is_finalized:
             return self
-        from nexau.archs.tool.builtin.agent_tool import call_sub_agent
+        from nexau.archs.tool.builtin.agent_tool import call_sub_agent_async
 
         nexau_package_path = Path(__file__).parent.parent.parent.parent
         if self.sub_agents:
@@ -379,7 +379,7 @@ class AgentConfig(
             # 2. 注册 Agent 工具
             agent_tool = Tool.from_yaml(
                 str(nexau_package_path / "archs" / "tool" / "builtin" / "description" / "agent_tool.yaml"),
-                binding=call_sub_agent,
+                binding=call_sub_agent_async,
                 description_suffix=sub_agent_description_suffix,
             )
             self.tools.append(agent_tool)
@@ -908,12 +908,16 @@ class AgentConfigBuilder:
             try:
                 sub_agent_name: str | None
                 sub_agent_source_id: str | None
+                sub_agent_timeout_seconds: float | None
+                sub_agent_max_calls_per_run: int | None
                 sub_agent_config_path_raw: str | None
                 inline_config: dict[str, Any] | None
                 inline_base_path: Path | None
                 if isinstance(sub_config, ExpandedSubAgentConfig):
                     sub_agent_name = sub_config.name
                     sub_agent_source_id = sub_config.source_id
+                    sub_agent_timeout_seconds = sub_config.timeout_seconds
+                    sub_agent_max_calls_per_run = sub_config.max_calls_per_run
                     sub_agent_config_path_raw = sub_config.config_path
                     inline_config = sub_config.inline_config
                     inline_base_path = sub_config.inline_base_path
@@ -921,6 +925,8 @@ class AgentConfigBuilder:
                     sub_config_dict = cast(dict[str, Any], sub_config)
                     sub_agent_name = cast(str | None, sub_config_dict.get("name"))
                     sub_agent_source_id = cast(str | None, sub_config_dict.get("source_id"))
+                    sub_agent_timeout_seconds = cast(float | None, sub_config_dict.get("timeout_seconds"))
+                    sub_agent_max_calls_per_run = cast(int | None, sub_config_dict.get("max_calls_per_run"))
                     sub_agent_config_path_raw = cast(str | None, sub_config_dict.get("config_path"))
                     inline_config = None
                     inline_base_path = None
@@ -962,6 +968,8 @@ class AgentConfigBuilder:
                     sub_agent_config.source_id = sub_agent_source_id
                 elif sub_agent_config.source_id is None:
                     sub_agent_config.source_id = f"local:sub_agent:{sub_agent_config.name}"
+                sub_agent_config.timeout_seconds = sub_agent_timeout_seconds
+                sub_agent_config.max_calls_per_run = sub_agent_max_calls_per_run
                 sub_agent_name_final = sub_agent_config.name
                 if sub_agent_name_final in sub_agents:
                     existing_source = sub_agents[sub_agent_name_final].source_id

--- a/nexau/archs/main_sub/config/expanded.py
+++ b/nexau/archs/main_sub/config/expanded.py
@@ -17,3 +17,5 @@ class ExpandedSubAgentConfig:
     source_id: str
     inline_config: dict[str, YamlValue]
     inline_base_path: Path
+    timeout_seconds: float | None = None
+    max_calls_per_run: int | None = None

--- a/nexau/archs/main_sub/config/schema.py
+++ b/nexau/archs/main_sub/config/schema.py
@@ -54,6 +54,8 @@ class SubAgentConfigEntry(BaseModel):
     name: str
     config_path: str
     source_id: str | None = None
+    timeout_seconds: float | None = Field(default=None, gt=0)
+    max_calls_per_run: int | None = Field(default=None, gt=0)
 
 
 class MCPServerBaseModel(BaseModel):

--- a/nexau/archs/main_sub/execution/subagent_manager.py
+++ b/nexau/archs/main_sub/execution/subagent_manager.py
@@ -14,10 +14,11 @@
 
 """Sub-agent management and lifecycle control."""
 
+import asyncio
 import logging
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from nexau.archs.main_sub.agent_state import AgentState
 from nexau.archs.main_sub.config import AgentConfig
@@ -29,6 +30,10 @@ if TYPE_CHECKING:
     from nexau.archs.session import SessionManager
 
 logger = logging.getLogger(__name__)
+
+
+class SubAgentBudgetExhaustedError(RuntimeError):
+    """Raised when a parent execution has exhausted a sub-agent call budget."""
 
 
 class SubAgentManager:
@@ -69,6 +74,20 @@ class SubAgentManager:
         # list(running_sub_agents.values()) 做 GIL-原子快照后再迭代, 避免
         # iteration-during-mutation 问题。无显式锁。
         self.running_sub_agents: dict[str, Agent] = {}
+        self._calls_by_parent_run: dict[str, int] = {}
+        self._budget_lock = threading.Lock()
+
+    def _admit_call(self, sub_agent_name: str, parent_agent_state: AgentState | None) -> None:
+        """Reserve one call from a per-parent-run budget."""
+        limit = self.sub_agents[sub_agent_name].max_calls_per_run
+        if limit is None or parent_agent_state is None:
+            return
+        run_id = parent_agent_state.run_id
+        with self._budget_lock:
+            used = self._calls_by_parent_run.get(run_id, 0)
+            if used >= limit:
+                raise SubAgentBudgetExhaustedError(sub_agent_name)
+            self._calls_by_parent_run[run_id] = used + 1
 
     def call_sub_agent(
         self,
@@ -113,6 +132,8 @@ class SubAgentManager:
             error_msg = f"Sub-agent '{sub_agent_name}' not found"
             logger.error(f"❌ {error_msg}")
             raise ValueError(error_msg)
+
+        self._admit_call(sub_agent_name, parent_agent_state)
 
         sub_agent_config = self.sub_agents[sub_agent_name]
         caller_sandbox_manager = parent_agent_state.sandbox_manager if parent_agent_state is not None else None
@@ -266,6 +287,8 @@ class SubAgentManager:
             logger.error(f"❌ {error_msg}")
             raise ValueError(error_msg)
 
+        self._admit_call(sub_agent_name, parent_agent_state)
+
         sub_agent_config = self.sub_agents[sub_agent_name]
         caller_sandbox_manager = parent_agent_state.sandbox_manager if parent_agent_state is not None else None
         if parent_agent_state is not None:
@@ -313,13 +336,43 @@ class SubAgentManager:
             if parallel_execution_id and parent_agent_state:
                 parent_agent_state.set_global_value("parallel_execution_id", parallel_execution_id)
 
-            result = await sub_agent.run_async(
-                message=message,
-                context=effective_context,
-                parent_agent_state=parent_agent_state,
-                custom_llm_client_provider=custom_llm_client_provider,
-                trace_id=trace_id,
+            child_task = asyncio.create_task(
+                sub_agent.run_async(
+                    message=message,
+                    context=effective_context,
+                    parent_agent_state=parent_agent_state,
+                    custom_llm_client_provider=custom_llm_client_provider,
+                    trace_id=trace_id,
+                )
             )
+            try:
+                done, pending = await asyncio.wait(
+                    {child_task},
+                    timeout=sub_agent_config.timeout_seconds,
+                )
+                if pending:
+                    sub_agent.executor.force_stop()
+                    child_task.cancel()
+                    await asyncio.wait_for(asyncio.gather(child_task, return_exceptions=True), timeout=1.0)
+                    try:
+                        sub_agent.sync_cleanup()
+                    except Exception:
+                        logger.warning("Failed to synchronously clean up deadline-exceeded sub-agent", exc_info=True)
+                    return cast(
+                        str,
+                        {
+                            "status": "partial",
+                            "reason": "AGENT_DEADLINE_EXCEEDED",
+                            "terminal": True,
+                            "sub_agent_name": sub_agent_name,
+                            "response": "Sub-agent deadline exceeded before it completed.",
+                        },
+                    )
+                result = next(iter(done)).result()
+            except TimeoutError:
+                raise RuntimeError("Sub-agent deadline cleanup timed out") from None
+            if isinstance(result, dict):
+                return cast(str, result)
             result = (
                 f"[sub_agent_id: {actual_sub_agent_id}] {result}\n"
                 f"Sub-agent finished (sub_agent_name: {sub_agent.agent_name}, "

--- a/nexau/archs/tool/builtin/agent_tool.py
+++ b/nexau/archs/tool/builtin/agent_tool.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from nexau.archs.main_sub.agent_state import AgentState
 from nexau.archs.main_sub.execution import SubAgentManager
+from nexau.archs.main_sub.execution.subagent_manager import SubAgentBudgetExhaustedError
 from nexau.archs.main_sub.framework_context import FrameworkContext
 
 
@@ -27,7 +28,7 @@ def _extract_sub_agent_id(text: str) -> str | None:
     return match.group(1) if match else None
 
 
-def call_sub_agent(
+async def call_sub_agent_async(
     sub_agent_name: str,
     message: str,
     sub_agent_id: str | None = None,
@@ -73,13 +74,23 @@ def call_sub_agent(
     # RFC-0024: 显式透传 trace_id 而非通过 AgentState backref。
     trace_id = ctx.trace_id if ctx is not None else None
     try:
-        result = subagent_manager.call_sub_agent(
+        result = await subagent_manager.call_sub_agent_async(
             sub_agent_name,
             message,
             sub_agent_id,
             parent_agent_state=agent_state,
             trace_id=trace_id,
         )
+        if isinstance(result, dict):
+            return result
+        if result.endswith("[Note: Maximum iteration limit reached]"):
+            return {
+                "status": "partial",
+                "reason": "MAX_ITERATIONS_REACHED",
+                "terminal": True,
+                "sub_agent_name": sub_agent_name,
+                "response": result,
+            }
         # RFC-0015: 从返回字符串开头提取实际 sub_agent_id（新建子代理时输入参数为 None）
         actual_sub_agent_id = _extract_sub_agent_id(result)
         return {
@@ -88,6 +99,14 @@ def call_sub_agent(
             "sub_agent_id": actual_sub_agent_id,
             "message": message,
             "result": result,
+        }
+    except SubAgentBudgetExhaustedError:
+        return {
+            "status": "partial",
+            "reason": "DELEGATION_BUDGET_EXHAUSTED",
+            "terminal": True,
+            "sub_agent_name": sub_agent_name,
+            "response": "The configured sub-agent call budget for this parent run is exhausted.",
         }
     except Exception as exc:
         # RFC-0015: 异常消息也包含 [sub_agent_id: ...] 前缀
@@ -101,4 +120,53 @@ def call_sub_agent(
         }
 
 
-__all__ = ["call_sub_agent"]
+def call_sub_agent(
+    sub_agent_name: str,
+    message: str,
+    sub_agent_id: str | None = None,
+    agent_state: AgentState | None = None,
+    ctx: FrameworkContext | None = None,
+) -> dict[str, Any]:
+    """Synchronous compatibility binding for legacy executor callers."""
+    if not sub_agent_id:
+        sub_agent_id = None
+    if agent_state is None:
+        return {"status": "error", "error": "Agent state not available"}
+    manager = agent_state.subagent_manager
+    if manager is None:
+        return {"status": "error", "error": "Sub-agent manager not available on agent_state"}
+    try:
+        result = manager.call_sub_agent(
+            sub_agent_name,
+            message,
+            sub_agent_id,
+            parent_agent_state=agent_state,
+            trace_id=ctx.trace_id if ctx is not None else None,
+        )
+        actual_id = _extract_sub_agent_id(result)
+        return {
+            "status": "success",
+            "sub_agent_name": sub_agent_name,
+            "sub_agent_id": actual_id,
+            "message": message,
+            "result": result,
+        }
+    except SubAgentBudgetExhaustedError:
+        return {
+            "status": "partial",
+            "reason": "DELEGATION_BUDGET_EXHAUSTED",
+            "terminal": True,
+            "sub_agent_name": sub_agent_name,
+            "response": "The configured sub-agent call budget for this parent run is exhausted.",
+        }
+    except Exception as exc:
+        return {
+            "status": "error",
+            "sub_agent_name": sub_agent_name,
+            "sub_agent_id": _extract_sub_agent_id(str(exc)),
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        }
+
+
+__all__ = ["call_sub_agent", "call_sub_agent_async"]

--- a/nexau/archs/tool/builtin/description/agent_tool.yaml
+++ b/nexau/archs/tool/builtin/description/agent_tool.yaml
@@ -9,6 +9,12 @@ description: >-
 
   Available sub-agent names are listed in the tool description for your context.
   `sub_agent_name` must match one of the parent agent's configured sub-agents.
+
+  Sub-agents may be configured with an optional invocation deadline and a
+  per-parent-run call budget. A deadline returns a terminal partial result with
+  reason `AGENT_DEADLINE_EXCEEDED`; an exhausted budget returns a terminal
+  partial result with reason `DELEGATION_BUDGET_EXHAUSTED`. Omitted controls
+  preserve the unlimited, backward-compatible behavior.
 formatter: nexau.archs.tool.formatters.agent:format_agent_tool_output
 input_schema:
   type: object

--- a/tests/unit/test_subagent_deadline_budget.py
+++ b/tests/unit/test_subagent_deadline_budget.py
@@ -1,0 +1,72 @@
+"""Public seam tests for sub-agent deadline and per-run budget contracts."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from nexau.archs.main_sub.agent_state import AgentState
+from nexau.archs.main_sub.config.schema import SubAgentConfigEntry
+from nexau.archs.main_sub.execution.subagent_manager import SubAgentBudgetExhaustedError
+from nexau.archs.tool.builtin.agent_tool import call_sub_agent_async
+
+
+def test_sub_agent_entry_round_trips_optional_controls() -> None:
+    entry = SubAgentConfigEntry(
+        name="worker",
+        config_path="worker.yaml",
+        timeout_seconds=2.5,
+        max_calls_per_run=2,
+    )
+    assert entry.model_dump(exclude_none=True)["timeout_seconds"] == 2.5
+    assert entry.model_dump(exclude_none=True)["max_calls_per_run"] == 2
+
+
+def test_sub_agent_entry_rejects_non_positive_timeout() -> None:
+    with pytest.raises(ValueError):
+        SubAgentConfigEntry(name="worker", config_path="worker.yaml", timeout_seconds=0)
+
+
+def test_sub_agent_entry_rejects_non_positive_call_budget() -> None:
+    with pytest.raises(ValueError):
+        SubAgentConfigEntry(name="worker", config_path="worker.yaml", max_calls_per_run=0)
+
+
+class _Manager:
+    def __init__(self, result: object) -> None:
+        self.result = result
+        self.calls = 0
+
+    async def call_sub_agent_async(self, *args: object, **kwargs: object) -> object:
+        self.calls += 1
+        if isinstance(self.result, BaseException):
+            raise self.result
+        return self.result
+
+
+def test_deadline_result_is_structured_terminal() -> None:
+    manager = _Manager({"status": "partial", "reason": "AGENT_DEADLINE_EXCEEDED", "terminal": True})
+    state = SimpleNamespace(subagent_manager=manager)
+    result = asyncio.run(call_sub_agent_async("worker", "work", agent_state=cast(AgentState, state)))
+    assert result["status"] == "partial"
+    assert result["reason"] == "AGENT_DEADLINE_EXCEEDED"
+    assert result["terminal"] is True
+
+
+def test_budget_exhaustion_does_not_start_a_second_call() -> None:
+    manager = _Manager(SubAgentBudgetExhaustedError("worker"))
+    state = SimpleNamespace(subagent_manager=manager)
+    result = asyncio.run(call_sub_agent_async("worker", "work", agent_state=cast(AgentState, state)))
+    assert result["reason"] == "DELEGATION_BUDGET_EXHAUSTED"
+    assert result["terminal"] is True
+    assert manager.calls == 1
+
+
+def test_max_iterations_marker_is_normalized_to_partial() -> None:
+    manager = _Manager("answer\n\n[Note: Maximum iteration limit reached]")
+    state = SimpleNamespace(subagent_manager=manager)
+    result = asyncio.run(call_sub_agent_async("worker", "work", agent_state=cast(AgentState, state)))
+    assert result["reason"] == "MAX_ITERATIONS_REACHED"
+    assert result["status"] == "partial"
+    assert result["terminal"] is True


### PR DESCRIPTION
## 变更
- 为 `SubAgentConfigEntry` / `AgentConfig` 增加可选 `timeout_seconds` 与 `max_calls_per_run`，省略时保持无限制兼容行为。
- Agent tool 改用异步 binding；deadline 超时执行 `force_stop`、取消 child task，并做 bounded cleanup，返回结构化 terminal partial：`AGENT_DEADLINE_EXCEEDED`。
- 预算以 parent `run_id` 隔离并加锁预占；耗尽时不启动下一 child，返回 `DELEGATION_BUDGET_EXHAUSTED`。
- 保留同步 `call_sub_agent` 兼容 binding，并补齐 Agent tool YAML description 与用户文档。

## NAC trace / API YAML
- NAC trace：本次未执行 NAC/Harness 部署，也未伪造线上 trace；现有 `trace_id` 显式透传路径保持不变，验证范围为本地可复现单元/生命周期测试。
- API YAML：已更新 `nexau/archs/tool/builtin/description/agent_tool.yaml` 的 binding-facing description，schema 的调用参数保持向后兼容（仅 `sub_agent_name`、`message` 必填）。

## 兼容性与已知限制
- 未配置 deadline/budget 的旧 YAML 与同步调用方继续可用。
- 同步路径仍可能阻塞调用线程；deadline 的 bounded cancellation 仅在异步 binding 上提供，不改变既有 sync 线程模型。

## 验证
- `python -m compileall`：通过。
- `ruff check .` / `ruff format --check .`：通过。
- `pyright`：0 errors。
- `make mypy`：494 files，无 errors。
- focused deadline/budget + stop propagation：27 passed。
- full unit（`MODEL=gpt-4o`）：4036 passed, 110 skipped, 4 xfailed；2 个 plugin quickstart `read_file` callable failures，与 `origin/main` 同命令基线完全一致。
