### PR TITLE
fix(compaction): truncate ToolUseBlock input payloads on compaction

### DIFF
--- a/nexau/archs/main_sub/execution/middleware/context_compaction/compact_stratigies/compact_tool_result.py
+++ b/nexau/archs/main_sub/execution/middleware/context_compaction/compact_stratigies/compact_tool_result.py
@@ -14,12 +14,26 @@
 
 """Tool result compaction strategy."""
 
+import json
 import logging
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from nexau.core.messages import BlockType, Message, Role, ToolResultBlock, ToolUseBlock
 
 logger = logging.getLogger(__name__)
+
+
+def _truncate_large_strings(obj: Any, max_length: int = 100) -> Any:
+    """Recursively truncates large strings in tool arguments."""
+    if isinstance(obj, str):
+        if len(obj) > max_length:
+            return obj[:50] + f"...<compacted {len(obj)} chars>..." + obj[-50:]
+        return obj
+    elif isinstance(obj, dict):
+        return {k: _truncate_large_strings(v, max_length) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_truncate_large_strings(v, max_length) for v in obj]
+    return obj
 
 
 class ToolResultCompaction:
@@ -143,7 +157,21 @@ class ToolResultCompaction:
                         if isinstance(block, ToolUseBlock):
                             tool_use_id_to_name[block.id] = block.name
 
-        # Process all messages
+        # Pass 1: Identify which tool_use_ids are being compacted
+        compacted_tool_use_ids: set[str] = set()
+        for i in range(start_idx, len(messages)):
+            msg = messages[i]
+            if msg.role == Role.TOOL and i not in protected_indices:
+                for block in msg.content:
+                    if isinstance(block, ToolResultBlock):
+                        should_compact_block = True
+                        if self.compactable_tools is not None:
+                            tool_name = tool_use_id_to_name.get(block.tool_use_id, "")
+                            should_compact_block = tool_name in self.compactable_tools
+                        if should_compact_block:
+                            compacted_tool_use_ids.add(block.tool_use_id)
+
+        # Pass 2: Rebuild messages, compacting target ToolResultBlocks and ToolUseBlocks
         compacted_count = 0
         for i in range(start_idx, len(messages)):
             msg = messages[i]
@@ -152,29 +180,42 @@ class ToolResultCompaction:
                 new_blocks: list[BlockType] = []
                 any_compacted = False
                 for block in msg.content:
-                    if isinstance(block, ToolResultBlock):
-                        # micro-compact: compactable_tools 过滤——仅压缩指定工具的结果
-                        should_compact_block = True
-                        if self.compactable_tools is not None:
-                            tool_name = tool_use_id_to_name.get(block.tool_use_id, "")
-                            should_compact_block = tool_name in self.compactable_tools
-
-                        if should_compact_block:
-                            new_blocks.append(
-                                ToolResultBlock(
-                                    tool_use_id=block.tool_use_id,
-                                    content="Tool call result has been compacted",
-                                    is_error=block.is_error,
-                                ),
-                            )
-                            any_compacted = True
-                        else:
-                            new_blocks.append(block)
+                    if isinstance(block, ToolResultBlock) and block.tool_use_id in compacted_tool_use_ids:
+                        new_blocks.append(
+                            ToolResultBlock(
+                                tool_use_id=block.tool_use_id,
+                                content="Tool call result has been compacted",
+                                is_error=block.is_error,
+                            ),
+                        )
+                        any_compacted = True
                     else:
                         new_blocks.append(block)
                 if any_compacted:
                     result.append(msg.model_copy(update={"content": new_blocks}))
                     compacted_count += 1
+                else:
+                    result.append(msg)
+            elif msg.role == Role.ASSISTANT:
+                # Truncate ToolUseBlock payloads if their result was compacted
+                new_blocks: list[BlockType] = []
+                any_compacted = False
+                for block in msg.content:
+                    if isinstance(block, ToolUseBlock) and block.id in compacted_tool_use_ids:
+                        truncated_input = _truncate_large_strings(block.input)
+                        truncated_raw_input = block.raw_input
+                        if truncated_raw_input is not None:
+                            try:
+                                parsed = json.loads(truncated_raw_input)
+                                truncated_raw_input = json.dumps(_truncate_large_strings(parsed), ensure_ascii=False)
+                            except Exception:
+                                pass # fallback if parsing fails
+                        new_blocks.append(block.model_copy(update={"input": truncated_input, "raw_input": truncated_raw_input}))
+                        any_compacted = True
+                    else:
+                        new_blocks.append(block)
+                if any_compacted:
+                    result.append(msg.model_copy(update={"content": new_blocks}))
                 else:
                     result.append(msg)
             else:


### PR DESCRIPTION
Resolves #18. Updates ToolResultCompaction to perform a two-pass sweep. When a ToolResult is compacted, this locates the corresponding ToolUseBlock in the ASSISTANT message and recursively truncates any strings larger than 100 characters in its input dict down to 100 chars, significantly shrinking the token footprint.