### PR TITLE
fix(compaction): keep hard truncation fallback in chronological order

### DIFF
--- a/nexau/archs/main_sub/execution/middleware/context_compaction/compact_stratigies/sliding_window.py
+++ b/nexau/archs/main_sub/execution/middleware/context_compaction/compact_stratigies/sliding_window.py
@@ -620,16 +620,27 @@ class SlidingWindowCompaction:
         retained_messages: list[Message] = []
 
         # Keep system message if present
+        system_kept = False
         if self.keep_system and messages and messages[0].role == Role.SYSTEM:
             retained_messages.append(messages[0])
             tokens_used += self.token_counter.count_tokens([messages[0]])
+            system_kept = True
 
-        # Iterate messages from newest to oldest
-        for msg in reversed(messages):
+        # Insert after the system message only when one was actually retained.
+        # Keying off self.keep_system instead would insert at index 1 of an
+        # empty list when the history carries no system message, which leaves
+        # the newest message stranded in front of the older ones.
+        insert_idx = 1 if system_kept else 0
+
+        # Iterate messages from newest to oldest. The system message is skipped
+        # because it is already retained; including it here would duplicate it
+        # and charge its tokens against the budget twice.
+        remaining = messages[1:] if system_kept else messages
+        for msg in reversed(remaining):
             msg_tokens = self.token_counter.count_tokens([msg])
             if tokens_used + msg_tokens > max_tokens:
                 break  # stop adding older messages
-            retained_messages.insert(1 if self.keep_system else 0, msg)
+            retained_messages.insert(insert_idx, msg)
             tokens_used += msg_tokens
 
         # Convert retained messages to concatenated text

--- a/tests/unit/test_sliding_window_coverage.py
+++ b/tests/unit/test_sliding_window_coverage.py
@@ -546,6 +546,34 @@ class TestHardTruncationFallback:
         assert isinstance(result, str)
         assert len(result) > 0
 
+    def test_keeps_chronological_order_without_system_message(self, compaction):
+        msgs = [Message(role=Role.USER, content=[TextBlock(text=f"msg-{i}")]) for i in range(5)]
+
+        result = compaction._hard_truncation_fallback(msgs)
+
+        assert result.splitlines() == ["msg-0", "msg-1", "msg-2", "msg-3", "msg-4"]
+
+    def test_keeps_chronological_order_with_system_message(self, compaction):
+        msgs = [
+            Message(role=Role.SYSTEM, content=[TextBlock(text="system prompt")]),
+            *[Message(role=Role.USER, content=[TextBlock(text=f"msg-{i}")]) for i in range(4)],
+        ]
+
+        result = compaction._hard_truncation_fallback(msgs)
+
+        assert result.splitlines() == ["system prompt", "msg-0", "msg-1", "msg-2", "msg-3"]
+
+    def test_system_message_counted_once_against_budget(self, compaction):
+        msgs = [
+            Message(role=Role.SYSTEM, content=[TextBlock(text="system prompt")]),
+            Message(role=Role.USER, content=[TextBlock(text="question")]),
+        ]
+
+        compaction._hard_truncation_fallback(msgs)
+
+        counted = [call.args[0][0] for call in compaction.token_counter.count_tokens.call_args_list]
+        assert sum(1 for msg in counted if msg.role == Role.SYSTEM) == 1
+
 
 # ---------------------------------------------------------------------------
 # _inject_summary


### PR DESCRIPTION
`_hard_truncation_fallback` picks its insert index from `self.keep_system` rather than from whether a system message was actually retained. keep_system defaults to True and plenty of histories reach `compact()` with no leading SYSTEM message, so every message goes to index 1 of a list that started empty. Five user messages come back as MSG-5, MSG-1, MSG-2, MSG-3, MSG-4.

The other half of it: when there is a system message, `reversed(messages)` walks over it a second time. It lands in the output twice and its tokens are charged twice against `_HARD_TRUNCATION_MAX_TOKENS`, so the fallback keeps fewer real messages than it has room for.

`TestHardTruncationFallback` only asserted the result was a non-empty string, which is how both stayed in. I added three cases covering order with and without a system message and the double token charge; all three fail on current main. This is the path that runs once every summary attempt has failed, so whatever it returns is the whole context the model gets.

Ran `uv run pytest` (4289 passed, 463 skipped), plus ruff and mypy on the two files.