### PR TITLE
docs: install over https instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ bash-only commands. See [Windows Support](./docs/windows.md).
 
 **Using pip:**
 ```bash
-# Install from the latest release tag using SSH (you need to use ssh because nexau is a private repo)
-pip install git+ssh://git@github.com/nex-agi/NexAU.git@v0.4.1
+# Install from the latest release tag
+pip install git+https://github.com/nex-agi/NexAU.git@v0.4.1
 
 # or visit https://github.com/nex-agi/nexau/releases/ and download whl, then
 pip install nexau-0.4.1-py3-none-any.whl
@@ -32,8 +32,8 @@ pip install nexau-0.4.1-py3-none-any.whl
 
 **Using uv:**
 ```bash
-# Install from the latest release tag using SSH
-uv pip install git+ssh://git@github.com/nex-agi/NexAU.git@v0.4.1
+# Install from the latest release tag
+uv pip install git+https://github.com/nex-agi/NexAU.git@v0.4.1
 
 # or visit https://github.com/nex-agi/nexau/releases/ and download whl, then
 uv pip install nexau-0.4.1-py3-none-any.whl
@@ -43,19 +43,19 @@ uv pip install nexau-0.4.1-py3-none-any.whl
 
 **Using pip:**
 ```bash
-pip install git+ssh://git@github.com/nex-agi/NexAU.git
+pip install git+https://github.com/nex-agi/NexAU.git
 ```
 
 **Using uv:**
 ```bash
-uv pip install git+ssh://git@github.com/nex-agi/NexAU.git
+uv pip install git+https://github.com/nex-agi/NexAU.git
 ```
 
 ### From Source
 
 ```bash
 # Clone the repository
-git clone git@github.com:nex-agi/NexAU.git
+git clone https://github.com/nex-agi/NexAU.git
 cd NexAU
 
 # Install dependencies using uv

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,8 +23,8 @@ backend。Git Bash 是可选 backend，仅在显式 bash-compatible 模式或 ba
 
 **使用 pip：**
 ```bash
-# 从最新发布版本安装（需要使用SSH，因为nexau是私有仓库）
-pip install git+ssh://git@github.com/nex-agi/NexAU.git@v0.4.1
+# 从最新发布版本安装
+pip install git+https://github.com/nex-agi/NexAU.git@v0.4.1
 
 # 或者访问 https://github.com/nex-agi/NexAU/releases/ 下载 whl 文件，然后
 pip install nexau-0.4.1-py3-none-any.whl
@@ -32,8 +32,8 @@ pip install nexau-0.4.1-py3-none-any.whl
 
 **使用 uv：**
 ```bash
-# 从最新发布版本安装（需要使用SSH）
-uv pip install git+ssh://git@github.com/nex-agi/NexAU.git@v0.4.1
+# 从最新发布版本安装
+uv pip install git+https://github.com/nex-agi/NexAU.git@v0.4.1
 
 # 或者访问 https://github.com/nex-agi/NexAU/releases/ 下载 whl 文件，然后
 uv pip install nexau-0.4.1-py3-none-any.whl
@@ -43,19 +43,19 @@ uv pip install nexau-0.4.1-py3-none-any.whl
 
 **使用 pip：**
 ```bash
-pip install git+ssh://git@github.com/nex-agi/NexAU.git
+pip install git+https://github.com/nex-agi/NexAU.git
 ```
 
 **使用 uv：**
 ```bash
-uv pip install git+ssh://git@github.com/nex-agi/NexAU.git
+uv pip install git+https://github.com/nex-agi/NexAU.git
 ```
 
 ### 从源码安装
 
 ```bash
 # 克隆仓库
-git clone git@github.com:nex-agi/NexAU.git
+git clone https://github.com/nex-agi/NexAU.git
 cd NexAU
 
 # 使用 uv 安装依赖

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,8 @@
 
 **Using pip:**
 ```bash
-# Install from the latest release tag using SSH (you need to use ssh because nexau is a private repo)
-pip install git+ssh://git@github.com/nex-agi/NexAU.git@v0.4.1
+# Install from the latest release tag
+pip install git+https://github.com/nex-agi/NexAU.git@v0.4.1
 
 # or visit https://github.com/nex-agi/nexau/releases/ and download whl, then
 pip install nexau-0.4.1-py3-none-any.whl
@@ -16,8 +16,8 @@ pip install nexau-0.4.1-py3-none-any.whl
 
 **Using uv:**
 ```bash
-# Install from the latest release tag using SSH
-uv pip install git+ssh://git@github.com/nex-agi/NexAU.git@v0.4.1
+# Install from the latest release tag
+uv pip install git+https://github.com/nex-agi/NexAU.git@v0.4.1
 
 # or visit https://github.com/nex-agi/nexau/releases/ and download whl, then
 uv pip install nexau-0.4.1-py3-none-any.whl
@@ -27,19 +27,19 @@ uv pip install nexau-0.4.1-py3-none-any.whl
 
 **Using pip:**
 ```bash
-pip install git+ssh://git@github.com/nex-agi/NexAU.git
+pip install git+https://github.com/nex-agi/NexAU.git
 ```
 
 **Using uv:**
 ```bash
-uv pip install git+ssh://git@github.com/nex-agi/NexAU.git
+uv pip install git+https://github.com/nex-agi/NexAU.git
 ```
 
 ### From Source
 
 ```bash
 # Clone the repository
-git clone git@github.com:nex-agi/NexAU.git
+git clone https://github.com/nex-agi/NexAU.git
 cd NexAU
 
 # Install dependencies using uv

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -32,7 +32,7 @@ features and tests.
 Install from source with the same Python workflow used on other platforms:
 
 ```powershell
-git clone git@github.com:nex-agi/NexAU.git
+git clone https://github.com/nex-agi/NexAU.git
 cd NexAU
 pip install uv
 uv sync


### PR DESCRIPTION
Every install command in the two READMEs and in docs/getting-started.md uses `git+ssh://`, and the comment above the first one says it has to because nexau is a private repo. It isn't one anymore, so the first command in the Quick Start hands anyone without a key on their GitHub account a `Permission denied (publickey)`.

Swapped the pip, uv and `git clone` lines over to https and dropped the private-repo note. I checked `uv pip install --no-deps git+https://github.com/nex-agi/NexAU.git@v0.4.1` with credentials disabled and it builds nexau 0.4.1.