### PR TITLE
fix(session): honor descending order_by in JSONL engine

### DIFF
--- a/nexau/archs/session/orm/jsonl_engine.py
+++ b/nexau/archs/session/orm/jsonl_engine.py
@@ -135,19 +135,13 @@ class JSONLDatabaseEngine(DatabaseEngine):
 
         if order_by:
             fields = (order_by,) if isinstance(order_by, str) else order_by
-
-            def sort_key(m: SQLModel) -> tuple[Any, ...]:
-                values: list[Any] = []
-                for field in fields:
-                    if field.startswith("-"):
-                        # For descending, we'll handle it differently
-                        values.append(m.__getattribute__(field[1:]))
-                    else:
-                        values.append(m.__getattribute__(field))
-                return tuple(values)
-
-            # Simple ascending sort for now
-            results.sort(key=sort_key)
+            for field in reversed(fields):
+                reverse = field.startswith("-")
+                field_name = field[1:] if reverse else field
+                results.sort(
+                    key=lambda m, name=field_name: m.__getattribute__(name),
+                    reverse=reverse,
+                )
 
         if offset:
             results = results[offset:]

--- a/tests/unit/test_jsonl_engine.py
+++ b/tests/unit/test_jsonl_engine.py
@@ -307,6 +307,55 @@ class TestJSONLDatabaseEngine:
 
             asyncio.run(run())
 
+    def test_find_many_with_order_by_descending(self) -> None:
+        """Prefix '-' on order_by must sort descending, matching SQL/memory engines."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            engine = JSONLDatabaseEngine(base_path=tmpdir)
+
+            async def run() -> None:
+                await engine.setup_models([JsonlUserModel])
+                await engine.create(JsonlUserModel(tenant_id="t1", user_id="u1", name="Charlie", age=35))
+                await engine.create(JsonlUserModel(tenant_id="t1", user_id="u2", name="Alice", age=25))
+                await engine.create(JsonlUserModel(tenant_id="t1", user_id="u3", name="Bob", age=30))
+
+                results = await engine.find_many(
+                    JsonlUserModel,
+                    filters=ComparisonFilter.eq("tenant_id", "t1"),
+                    order_by="-age",
+                )
+                assert [r.age for r in results] == [35, 30, 25]
+
+                newest = await engine.find_many(
+                    JsonlUserModel,
+                    filters=ComparisonFilter.eq("tenant_id", "t1"),
+                    order_by="-age",
+                    limit=1,
+                )
+                assert len(newest) == 1
+                assert newest[0].age == 35
+
+            asyncio.run(run())
+
+    def test_find_many_with_mixed_order_by(self) -> None:
+        """Multi-field order_by must honor per-field '-' prefixes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            engine = JSONLDatabaseEngine(base_path=tmpdir)
+
+            async def run() -> None:
+                await engine.setup_models([JsonlUserModel])
+                await engine.create(JsonlUserModel(tenant_id="t1", user_id="u1", name="Alice", age=30))
+                await engine.create(JsonlUserModel(tenant_id="t1", user_id="u2", name="Carol", age=30))
+                await engine.create(JsonlUserModel(tenant_id="t1", user_id="u3", name="Bob", age=25))
+
+                results = await engine.find_many(
+                    JsonlUserModel,
+                    filters=ComparisonFilter.eq("tenant_id", "t1"),
+                    order_by=("-age", "name"),
+                )
+                assert [r.name for r in results] == ["Alice", "Carol", "Bob"]
+
+            asyncio.run(run())
+
     def test_find_many_no_filters(self) -> None:
         """Test find_many without filters returns all records."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
JSONL `find_many` treated `order_by="-age"` as ascending. It stripped the `-` prefix and then always called `sort()` without `reverse`. SQL and memory engines already honor that prefix as descending.

`AgentRunActionService._scan_actions_desc` asks for `order_by=("-created_at_ns", "-action_id")` with a page `limit`. On JSONL that returns the oldest page, so `load_messages` folds history in the wrong direction.

Sort now matches the memory engine: walk fields last-to-first and apply `reverse` per `-` prefix. `test_find_many_with_order_by_descending` and `test_find_many_with_mixed_order_by` failed on main (`[25, 30, 35]` vs `[35, 30, 25]`) and pass after the change. Full `tests/unit/test_jsonl_engine.py`: 30 passed.
